### PR TITLE
feat: Overwriting User-Agent on CLI requests for MCP mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
-        "heroku": "10.4.1-alpha.3",
+        "heroku": "10.4.1-alpha.4",
         "jsonschema": "^1.5.0",
         "tar-stream": "^3.1.7",
         "zod": "^3.24.2",
@@ -11276,9 +11276,9 @@
       "license": "MIT"
     },
     "node_modules/heroku": {
-      "version": "10.4.1-alpha.3",
-      "resolved": "https://registry.npmjs.org/heroku/-/heroku-10.4.1-alpha.3.tgz",
-      "integrity": "sha512-DGpZAD66ENRAoJRJSD2EaHGdFSZwH30jM0yD+/a0br1SNsRpZGo2/VvnwwxirFvJWiaGGrrAC4kDJ7W0ksb6dw==",
+      "version": "10.4.1-alpha.4",
+      "resolved": "https://registry.npmjs.org/heroku/-/heroku-10.4.1-alpha.4.tgz",
+      "integrity": "sha512-lqPS6t3tA/l+G9WKvdhHY2V2rVm3k90yOQaVj/CSNYjcYC8Kgjfdn9Gg2DEF880sqR3weJjdK/jwOpsSNPQ6FQ==",
       "license": "ISC",
       "dependencies": {
         "@heroku-cli/color": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "type": "module",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",
-    "heroku": "10.4.1-alpha.3",
+    "heroku": "10.4.1-alpha.4",
     "jsonschema": "^1.5.0",
     "tar-stream": "^3.1.7",
     "zod": "^3.24.2",

--- a/src/repl/heroku-cli-repl.spec.ts
+++ b/src/repl/heroku-cli-repl.spec.ts
@@ -1,8 +1,10 @@
 import { EventEmitter } from 'node:events';
-import * as childProcess from 'node:child_process';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { HerokuREPL } from './heroku-cli-repl.js';
+import * as pjson from '../../package.json' with { type: 'json' };
+
+const VERSION = pjson.default.version;
 
 describe('HerokuREPL', () => {
   let repl: HerokuREPL;
@@ -48,6 +50,12 @@ describe('HerokuREPL', () => {
     it('should create a new process when initialized', () => {
       expect(spawnStub.calledOnce).to.be.true;
       expect(spawnStub.firstCall.args[2].env.HEROKU_MCP_MODE).to.equal('true');
+      expect(spawnStub.firstCall.args[2].env.HEROKU_MCP_SERVER_VERSION).to.equal(VERSION);
+      expect(spawnStub.firstCall.args[2].env.HEROKU_HEADERS).to.equal(
+        JSON.stringify({
+          'User-Agent': `Heroku-MCP-Server/${VERSION} (${process.platform}; ${process.arch}; node/${process.version})`
+        })
+      );
     });
   });
 


### PR DESCRIPTION
## Description

Here we include changes to:
- Overwrite the User-Agent value sent with Heroku CLI requests when running in MCP mode by means of setting the `HEROKU_HEADERS` env var with the required value on the spawned CLI process.
- Additionally we set the env var `HEROKU_MCP_SERVER_VERSION` that will be used by the CLI to know the MCP server version and add it to the information sent to Backboard and Honeycomb to enable us to create metrics based on MCP server usage (see [PR #3279](https://github.com/heroku/cli/pull/3279)).

## Testing
- Checkout this branch and run ```npm install && npm run build```
- Start the MCP inspector with ```npx @modelcontextprotocol/inspector dist/index.js```
- Open the inspector web interface (usually at http://localhost:5173, but look for the message `🔍 MCP Inspector is up and running at ...` as it might be up at a different port).
- On the inspector click the `Add Environment Variable` and add the variable `DEBUG` with value `http,http:headers`.
- Click `Connect` and then `List Tools`. Select one of the tools like `list_apps` and click Run Tool.
- On the Tool Results, check that requests to Platform API use the MCP version user agent string instead of the CLI version. This doesn't effect Backboard requests, though, because it doesn't honor the `HEROKU_HEADERS` env var like `@heroku/cli-command`, but that's not a problem because we will be sending the version on the payload.

## SOC2 Compliance
GUS Work Item: [W-18205123](https://gus.lightning.force.com/a07EE00002CCpQVYA1)