### PR TITLE
fix: use the correct mcpServers json format

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,8 @@ Add this snippet to your `claude_desktop_config.json`:
 {
   "mcpServers": {
     "heroku": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@heroku/mcp-server"]
-      },
+      "command": "npx",
+      "args": ["-y", "@heroku/mcp-server"],
       "env": {
         "HEROKU_API_KEY": "<YOUR_HEROKU_AUTH_TOKEN>"
       }
@@ -73,10 +71,8 @@ Add this snippet to your Zed `settings.json`:
 {
   "context_servers": {
     "heroku": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@heroku/mcp-server"]
-      },
+      "command": "npx",
+      "args": ["-y", "@heroku/mcp-server"],
       "env": {
         "HEROKU_API_KEY": "<YOUR_HEROKU_AUTH_TOKEN>"
       }
@@ -125,7 +121,7 @@ Add this snippet to your Windsurf `mcp_config.json`:
 }
 ```
 
-### [Cline](https://cline.ai)
+### [Cline](https://cline.bot)
 
 Add this snippet to your Cline `config.json`:
 
@@ -133,10 +129,8 @@ Add this snippet to your Cline `config.json`:
 {
   "mcpServers": {
     "heroku": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@heroku/mcp-server"]
-      },
+      "command": "npx",
+      "args": ["-y", "@heroku/mcp-server"],
       "env": {
         "HEROKU_API_KEY": "<YOUR_HEROKU_AUTH_TOKEN>"
       }
@@ -166,7 +160,7 @@ Add this snippet to your VSCode `settings.json` or `.vscode/mcp.json`:
 }
 ```
 
-### [Trae](https://trae.dev)
+### [Trae](https://trae.ai)
 
 Add this snippet to your Trae `mcp_settings.json`:
 
@@ -174,10 +168,8 @@ Add this snippet to your Trae `mcp_settings.json`:
 {
   "mcpServers": {
     "heroku": {
-      "command": {
-        "path": "npx",
-        "args": ["-y", "@heroku/mcp-server"]
-      },
+      "command": "npx",
+      "args": ["-y", "@heroku/mcp-server"],
       "env": {
         "HEROKU_API_KEY": "<YOUR_HEROKU_AUTH_TOKEN>"
       }

--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ Add this snippet to your Zed `settings.json`:
 {
   "context_servers": {
     "heroku": {
-      "command": "npx",
-      "args": ["-y", "@heroku/mcp-server"],
+      "command": {
+        "path": "npx",
+        "args": ["-y", "@heroku/mcp-server"]
+      },
       "env": {
         "HEROKU_API_KEY": "<YOUR_HEROKU_AUTH_TOKEN>"
       }


### PR DESCRIPTION
It uses the correct JSON format to install MPCs and fixes a couple of broken links

Update: I reverted `zed` which is the one that manages config differently