### PR TITLE
feat: Add tools for listing and provisioning AI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # heroku-mcp-server
 
 [![smithery badge](https://smithery.ai/badge/@heroku/heroku-mcp-server)](https://smithery.ai/server/@heroku/heroku-mcp-server)
+
 > The Heroku Platform MCP Server works on Common Runtime, Cedar Private and Shield Spaces, and Fir Private Spaces.
 
 ## Deploy on Heroku
@@ -388,7 +389,8 @@ Note: the debugger automatically builds your TypeScript files before launching.
 
 ### Installing via Smithery
 
-To install Heroku Platform MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@heroku/heroku-mcp-server):
+To install Heroku Platform MCP Server for Claude Desktop automatically via
+[Smithery](https://smithery.ai/server/@heroku/heroku-mcp-server):
 
 ```bash
 npx -y @smithery/cli install @heroku/heroku-mcp-server --client claude

--- a/app.json
+++ b/app.json
@@ -2,11 +2,7 @@
   "name": "mcp-heroku-server",
   "description": "MCP Server for interacting with the Heroku platform API",
   "repository": "https://github.com/heroku/heroku-mcp-server",
-  "keywords": [
-    "node",
-    "mcp",
-    "heroku"
-  ],
+  "keywords": ["node", "mcp", "heroku"],
   "buildpacks": [
     {
       "url": "heroku/nodejs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
+        "@heroku/plugin-ai": "^0.0.11",
         "@modelcontextprotocol/sdk": "^1.8.0",
-        "heroku": "10.6.2-alpha.0",
+        "heroku": "10.7.1-alpha.0",
         "jsonschema": "^1.5.0",
         "tar-stream": "^3.1.7",
         "zod": "^3.24.2",
@@ -1456,6 +1457,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku/plugin-ai": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@heroku/plugin-ai/-/plugin-ai-0.0.11.tgz",
+      "integrity": "sha512-6VOfO4VapFSwnx5POotitBVqR7KndL4FX8HBw6IXuNpNksHuJSrxFMBSiCSz4wlLis7upfBBmjrWghTWtqvivw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@heroku-cli/color": "^2",
+        "@heroku-cli/command": "^11.5.0",
+        "@heroku-cli/schema": "^1.0.25",
+        "@oclif/core": "^2.16.0",
+        "@oclif/plugin-help": "^5",
+        "open": "^8.4.2",
+        "printf": "^0.6.1",
+        "tsheredoc": "^1"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@heroku/plugin-ai/node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@heroku/plugin-ai/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku/plugin-ai/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@heroku/plugin-ai/node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10844,6 +10917,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -11276,9 +11358,9 @@
       "license": "MIT"
     },
     "node_modules/heroku": {
-      "version": "10.6.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/heroku/-/heroku-10.6.2-alpha.0.tgz",
-      "integrity": "sha512-1ZSLGl/JoQBjV1PHhCygt+qD1jYuyuFDTY/vd/ASfwHNW5zJiYE3xWrFloV40GHfFCelCYecRrmT49BrSoEE3Q==",
+      "version": "10.7.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/heroku/-/heroku-10.7.1-alpha.0.tgz",
+      "integrity": "sha512-sPhrTcJG6DpxwCZM4DfufcEjpkXWJqNHV1iXjQa/s9R7bR1j7bKew74WcWzt9S2/0K76r3IRO2v4ekjbXvtlDA==",
       "license": "ISC",
       "dependencies": {
         "@heroku-cli/color": "2.0.1",
@@ -11288,8 +11370,9 @@
         "@heroku-cli/schema": "^1.0.25",
         "@heroku/buildpack-registry": "^1.0.1",
         "@heroku/eventsource": "^1.0.7",
-        "@heroku/heroku-cli-util": "^8.0.13",
+        "@heroku/heroku-cli-util": "^9.0.1",
         "@heroku/http-call": "^5.4.0",
+        "@heroku/plugin-ai": "^1.0.1",
         "@inquirer/prompts": "^5.0.5",
         "@oclif/core": "^2.16.0",
         "@oclif/plugin-commands": "2.2.28",
@@ -11384,6 +11467,121 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/heroku/node_modules/@heroku/heroku-cli-util": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@heroku/heroku-cli-util/-/heroku-cli-util-9.0.1.tgz",
+      "integrity": "sha512-K12S2HlsRmlgM3j5ssmBbWfVbhAQOY/EFxB4p8hGCBVkVv8C6N/teeHfQjQ9ktFu1BmLCfQoJ0ejpIeoN0qR2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@heroku-cli/color": "^2.0.4",
+        "@heroku-cli/command": "^11.5.0",
+        "@heroku/http-call": "^5.4.0",
+        "@oclif/core": "^2.16.0",
+        "@types/chai": "^4.3.13",
+        "chai": "^4.4.1",
+        "debug": "^4.4.0",
+        "nock": "^13.2.9",
+        "stdout-stderr": "^0.1.13",
+        "tunnel-ssh": "4.1.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/heroku/node_modules/@heroku/heroku-cli-util/node_modules/@heroku-cli/color": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@heroku-cli/color/-/color-2.0.4.tgz",
+      "integrity": "sha512-CjG4Mlj8B5ZELk8mzgJLUEb1fH+zckrqtufgxeKG9jLMyUCRyHNhEEBT9XHadPE6HbKTXMzW941QsmK6qVgNng==",
+      "license": "ISC",
+      "dependencies": {
+        "ansi-styles": "^4.3.0",
+        "chalk": "^4.1.2",
+        "supports-color": "^7.2.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/heroku/node_modules/@heroku/heroku-cli-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/heroku/node_modules/@heroku/heroku-cli-util/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/heroku/node_modules/@heroku/heroku-cli-util/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/heroku/node_modules/@heroku/heroku-cli-util/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/heroku/node_modules/@heroku/heroku-cli-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/heroku/node_modules/@heroku/plugin-ai": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@heroku/plugin-ai/-/plugin-ai-1.0.1.tgz",
+      "integrity": "sha512-oPBr4kyDckjLkTW4WfslDyodOBphSLPgbBimr7Gx0DAswJPFmV8Et3y9lvlatkFf86jTbQFgctY/mkBF913FdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@heroku-cli/color": "^2",
+        "@heroku-cli/command": "^11.5.0",
+        "@heroku-cli/schema": "^1.0.25",
+        "@oclif/core": "^2.16.0",
+        "@oclif/plugin-help": "^5",
+        "open": "^8.4.2",
+        "printf": "^0.6.1",
+        "tsheredoc": "^1"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/heroku/node_modules/@inquirer/checkbox": {
@@ -11656,6 +11854,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/heroku/node_modules/@types/chai": {
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
+      "license": "MIT"
+    },
     "node_modules/heroku/node_modules/@types/node": {
       "version": "22.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
@@ -11674,6 +11878,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/heroku/node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/heroku/node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -11681,6 +11894,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/heroku/node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/heroku/node_modules/chalk": {
@@ -11707,6 +11938,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/heroku/node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/heroku/node_modules/cli-cursor": {
@@ -11776,6 +12019,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/heroku/node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/heroku/node_modules/define-lazy-prop": {
@@ -12028,6 +12283,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/heroku/node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/heroku/node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -12094,6 +12358,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/heroku/node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/heroku/node_modules/restore-cursor": {
@@ -12176,6 +12449,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/heroku/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/heroku/node_modules/type-fest": {
       "version": "0.21.3",
@@ -15168,6 +15450,20 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "license": "MIT"
     },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -16592,6 +16888,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proto-list": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   },
   "type": "module",
   "dependencies": {
+    "@heroku/plugin-ai": "^0.0.11",
     "@modelcontextprotocol/sdk": "^1.8.0",
-    "heroku": "10.6.2-alpha.0",
+    "heroku": "10.7.1-alpha.0",
     "jsonschema": "^1.5.0",
     "tar-stream": "^3.1.7",
     "zod": "^3.24.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import * as ps from './tools/ps.js';
 import * as pipelines from './tools/pipelines.js';
 import * as deployToHeroku from './tools/deploy-to-heroku.js';
 import * as logs from './tools/logs.js';
+import * as ai from './tools/ai.js';
 
 import { HerokuREPL } from './repl/heroku-cli-repl.js';
 
@@ -74,6 +75,10 @@ pipelines.registerPipelinesInfoTool(server, herokuRepl);
 // Deploy-to-Heroku tool
 deployToHeroku.registerDeployToHerokuTool(server);
 deployToHeroku.registerDeployOneOffDynoTool(server);
+
+// AI-related tools
+ai.registerListAiAvailableModelsTool(server, herokuRepl);
+ai.registerProvisionAiModelTool(server, herokuRepl);
 
 /**
  * Run the server

--- a/src/tools/ai.spec.ts
+++ b/src/tools/ai.spec.ts
@@ -1,0 +1,123 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { HerokuREPL } from '../repl/heroku-cli-repl.js';
+import {
+  registerListAiAvailableModelsTool,
+  registerProvisionAiModelTool,
+  provisionAiModelOptionsSchema
+} from './ai.js';
+import { CommandBuilder } from '../utils/command-builder.js';
+import { TOOL_COMMAND_MAP } from '../utils/tool-commands.js';
+
+describe('ai topic tools', () => {
+  describe('registerListAiAvailableModelsTool', () => {
+    let server: sinon.SinonStubbedInstance<McpServer>;
+    let herokuRepl: sinon.SinonStubbedInstance<HerokuREPL>;
+    let toolCallback: Function;
+
+    beforeEach(() => {
+      server = sinon.createStubInstance(McpServer);
+      herokuRepl = sinon.createStubInstance(HerokuREPL);
+
+      server.tool.callsFake((_name: string, _description: string, _schema: any, callback: Function) => {
+        toolCallback = callback;
+        return server;
+      });
+
+      registerListAiAvailableModelsTool(server, herokuRepl);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('registers the tool with correct name', () => {
+      expect(server.tool.calledOnce).to.be.true;
+      const call = server.tool.getCall(0);
+      expect(call.args[0]).to.equal('list_ai_available_models');
+    });
+
+    it('executes command successfully', async () => {
+      const expectedOutput =
+        ' Model                     Type              Supported regions \n' +
+        ' ───────────────────────── ───────────────── ───────────────── \n' +
+        ' claude-3-5-haiku          text-to-text      us                \n' +
+        ' claude-3-5-sonnet-latest  text-to-text      us                \n';
+      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.LIST_AI_AVAILABLE_MODELS).build();
+
+      herokuRepl.executeCommand.resolves(expectedOutput);
+
+      const result = await toolCallback({}, {});
+      expect(herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
+      expect(result).to.deep.equal({
+        content: [{ type: 'text', text: expectedOutput }]
+      });
+    });
+  });
+
+  describe('provisionAiModelTool', () => {
+    let server: sinon.SinonStubbedInstance<McpServer>;
+    let herokuRepl: sinon.SinonStubbedInstance<HerokuREPL>;
+    let toolCallback: Function;
+
+    beforeEach(() => {
+      server = sinon.createStubInstance(McpServer);
+      herokuRepl = sinon.createStubInstance(HerokuREPL);
+
+      server.tool.callsFake((_name: string, _description: string, _schema: any, callback: Function) => {
+        toolCallback = callback;
+        return server;
+      });
+
+      registerProvisionAiModelTool(server, herokuRepl);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('registers the tool with correct name and schema', () => {
+      expect(server.tool.calledOnce).to.be.true;
+      const call = server.tool.getCall(0);
+      expect(call.args[0]).to.equal('provision_ai_model');
+      expect(call.args[2]).to.deep.equal(provisionAiModelOptionsSchema.shape);
+    });
+
+    it('executes command successfully with required arguments', async () => {
+      const expectedOutput =
+        'Provisioning access to claude-3-5-sonnet-latest for app test-app... done\n' +
+        'Created claude-3-5-sonnet-latest as INFERENCE on test-app';
+      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.PROVISION_AI_MODEL)
+        .addPositionalArguments({ modelName: 'claude-3-5-sonnet-latest' })
+        .addFlags({ app: 'test-app' })
+        .build();
+
+      herokuRepl.executeCommand.resolves(expectedOutput);
+
+      const result = await toolCallback({ app: 'test-app', modelName: 'claude-3-5-sonnet-latest' }, {});
+      expect(herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
+      expect(result).to.deep.equal({
+        content: [{ type: 'text', text: expectedOutput }]
+      });
+    });
+
+    it('executes command successfully with optional "--as" parameter', async () => {
+      const expectedOutput =
+        'Provisioning access to claude-3-5-sonnet-latest for app test-app as MY_MODEL... done\n' +
+        'Created claude-3-5-sonnet-latest as MY_MODEL on test-app';
+      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.PROVISION_AI_MODEL)
+        .addPositionalArguments({ modelName: 'claude-3-5-sonnet-latest' })
+        .addFlags({ app: 'test-app', as: 'MY_MODEL' })
+        .build();
+
+      herokuRepl.executeCommand.resolves(expectedOutput);
+
+      const result = await toolCallback({ app: 'test-app', modelName: 'claude-3-5-sonnet-latest', as: 'MY_MODEL' }, {});
+      expect(herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
+      expect(result).to.deep.equal({
+        content: [{ type: 'text', text: expectedOutput }]
+      });
+    });
+  });
+});

--- a/src/tools/ai.ts
+++ b/src/tools/ai.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { handleCliOutput } from '../utils/handle-cli-output.js';
+import { CommandBuilder } from '../utils/command-builder.js';
+import { TOOL_COMMAND_MAP } from '../utils/tool-commands.js';
+import { HerokuREPL } from '../repl/heroku-cli-repl.js';
+import { McpToolResponse } from '../utils/mcp-tool-response.js';
+
+/**
+ * Register list_ai_available_models tool
+ *
+ * @param server MCP server instance
+ * @param herokuRepl Heroku REPL instance
+ */
+export const registerListAiAvailableModelsTool = (server: McpServer, herokuRepl: HerokuREPL): void => {
+  server.tool(
+    'list_ai_available_models',
+    'List Heroku AI available inference models',
+    z.object({}).shape,
+    async (): Promise<McpToolResponse> => {
+      const command = new CommandBuilder(TOOL_COMMAND_MAP.LIST_AI_AVAILABLE_MODELS).build();
+
+      const output = await herokuRepl.executeCommand(command);
+      return handleCliOutput(output);
+    }
+  );
+};
+
+/**
+ * Schema for provisioning an AI model
+ */
+export const provisionAiModelOptionsSchema = z.object({
+  app: z.string().describe('Target app name for AI model access provisioning'),
+  modelName: z
+    .string()
+    .describe(
+      'Name of the AI model to provision access for. Valid model names can be found with tool "list_ai_available_models"'
+    ),
+  as: z
+    .string()
+    .optional()
+    .describe('Alias for the model resource when attaching to the app. Randomly generated if not provided.')
+});
+
+/**
+ * Type for provision AI model options
+ */
+export type ProvisionAiModelOptions = z.infer<typeof provisionAiModelOptionsSchema>;
+
+/**
+ * Register create_app tool
+ *
+ * @param server MCP server instance
+ * @param herokuRepl Heroku REPL instance
+ */
+export const registerProvisionAiModelTool = (server: McpServer, herokuRepl: HerokuREPL): void => {
+  server.tool(
+    'provision_ai_model',
+    'Provision access to an AI model for an app',
+    provisionAiModelOptionsSchema.shape,
+    async (options: ProvisionAiModelOptions): Promise<McpToolResponse> => {
+      const command = new CommandBuilder(TOOL_COMMAND_MAP.PROVISION_AI_MODEL)
+        .addPositionalArguments({ modelName: options.modelName })
+        .addFlags({
+          app: options.app,
+          as: options.as
+        })
+        .build();
+
+      const output = await herokuRepl.executeCommand(command);
+      return handleCliOutput(output);
+    }
+  );
+};

--- a/src/utils/tool-commands.ts
+++ b/src/utils/tool-commands.ts
@@ -49,6 +49,11 @@ export const TOOL_COMMAND_MAP = {
   PIPELINES_CREATE: 'pipelines:create',
   PIPELINES_PROMOTE: 'pipelines:promote',
   PIPELINES_INFO: 'pipelines:info',
+
   // Logs commands
-  LOGS: 'logs'
+  LOGS: 'logs',
+
+  // AI commands
+  LIST_AI_AVAILABLE_MODELS: 'ai:models:list',
+  PROVISION_AI_MODEL: 'ai:models:create'
 } as const;


### PR DESCRIPTION
## Description

Here we introduce two new tools: `list_ai_available_models` and `provision_ai_model`. Both of these tools are based on commands provided by the Heroku CLI Plugin AI, which has now been included as a direct dependency for the Core CLI version bundled in this package. This was done to ensure that the AI commands are available no matter if the user has the Heroku CLI and the plugin installed.

## Testing

- Checkout this branch with `git pull && git checkout sbosio/mia-plugin-tools`
- Ensure you're using the correct version of Node (>20.x)
- If you have the AI plugin installed, uninstall it: `heroku plugins:uninstall @heroku/plugin-ai`
- Run `npm install && npm run build`
- Run `npx -y @modelcontextprotocol/inspector@latest ./dist/index.js`
- Open the inspector on your browser (usually at http://127.0.0.1:6274)
- Connect to the STDIO MCP Server and list the server tools. Two new tools should appear: `list_ai_available_models` and `provision_ai_model`.
- Test each one of the tools, providing correct required parameters. Both should succeed.
- Reinstall your Heroku CLI Plugin AI, if you uninstalled it: `heroku plugins:install @heroku/plugin-ai`

## SOC2 Compliance
GUS Work Item: [W-18542147](https://gus.lightning.force.com/a07EE00002EXcPGYA1) (Heroku internal).
