### PR TITLE
fix: Updating Core CLI dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@heroku/plugin-ai": "^1.0.1",
         "@modelcontextprotocol/sdk": "^1.8.0",
-        "heroku": "10.7.1-alpha.1",
+        "heroku": "10.8.0-alpha.0",
         "jsonschema": "^1.5.0",
         "tar-stream": "^3.1.7",
         "zod": "^3.24.2",
@@ -10910,15 +10910,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -11351,9 +11342,9 @@
       "license": "MIT"
     },
     "node_modules/heroku": {
-      "version": "10.7.1-alpha.1",
-      "resolved": "https://registry.npmjs.org/heroku/-/heroku-10.7.1-alpha.1.tgz",
-      "integrity": "sha512-ld35ABN9oynfoy051HZaDyy58kzilShRJxAawyDP/qyNm7wDfRJvcCw0rohgXWiOWIDFni9pGObYS9+ZSi9thQ==",
+      "version": "10.8.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/heroku/-/heroku-10.8.0-alpha.0.tgz",
+      "integrity": "sha512-NRHfVEUvInk62Ckmrqcokt/XogzKGFK5DBxZQqiGvIDnaMO3TSXHF3Z2o5Jq7ww+xZtTuO1nzcFk1iL51+zfkA==",
       "license": "ISC",
       "dependencies": {
         "@heroku-cli/color": "2.0.1",
@@ -11363,7 +11354,7 @@
         "@heroku-cli/schema": "^1.0.25",
         "@heroku/buildpack-registry": "^1.0.1",
         "@heroku/eventsource": "^1.0.7",
-        "@heroku/heroku-cli-util": "^9.0.1",
+        "@heroku/heroku-cli-util": "^9.0.2",
         "@heroku/http-call": "^5.4.0",
         "@heroku/plugin-ai": "^1.0.1",
         "@inquirer/prompts": "^5.0.5",
@@ -11463,20 +11454,16 @@
       }
     },
     "node_modules/heroku/node_modules/@heroku/heroku-cli-util": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@heroku/heroku-cli-util/-/heroku-cli-util-9.0.1.tgz",
-      "integrity": "sha512-K12S2HlsRmlgM3j5ssmBbWfVbhAQOY/EFxB4p8hGCBVkVv8C6N/teeHfQjQ9ktFu1BmLCfQoJ0ejpIeoN0qR2Q==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@heroku/heroku-cli-util/-/heroku-cli-util-9.0.2.tgz",
+      "integrity": "sha512-49A6h/Mrq7yoFLSWesQa0/lLulEefU+yr+AxOvNW4ypHhjmfgseCEZgMehy5R5G3llEbDjUvtPg7SqAkFDDl1w==",
       "license": "ISC",
       "dependencies": {
         "@heroku-cli/color": "^2.0.4",
         "@heroku-cli/command": "^11.5.0",
         "@heroku/http-call": "^5.4.0",
         "@oclif/core": "^2.16.0",
-        "@types/chai": "^4.3.13",
-        "chai": "^4.4.1",
         "debug": "^4.4.0",
-        "nock": "^13.2.9",
-        "stdout-stderr": "^0.1.13",
         "tunnel-ssh": "4.1.6"
       },
       "engines": {
@@ -11828,12 +11815,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/heroku/node_modules/@types/chai": {
-      "version": "4.3.20",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
-      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
-      "license": "MIT"
-    },
     "node_modules/heroku/node_modules/@types/node": {
       "version": "22.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
@@ -11852,15 +11833,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/heroku/node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/heroku/node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -11868,24 +11840,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/heroku/node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/heroku/node_modules/chalk": {
@@ -11912,18 +11866,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/heroku/node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/heroku/node_modules/cli-cursor": {
@@ -11993,18 +11935,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/heroku/node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/heroku/node_modules/define-lazy-prop": {
@@ -12257,15 +12187,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/heroku/node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/heroku/node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -12332,15 +12253,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/heroku/node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/heroku/node_modules/restore-cursor": {
@@ -12423,15 +12335,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
-    },
-    "node_modules/heroku/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/heroku/node_modules/type-fest": {
       "version": "0.21.3",
@@ -15424,20 +15327,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "license": "MIT"
     },
-    "node_modules/nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -16865,15 +16754,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/proto-list": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@heroku/plugin-ai": "^1.0.1",
     "@modelcontextprotocol/sdk": "^1.8.0",
-    "heroku": "10.7.1-alpha.1",
+    "heroku": "10.8.0-alpha.0",
     "jsonschema": "^1.5.0",
     "tar-stream": "^3.1.7",
     "zod": "^3.24.2",


### PR DESCRIPTION
## Description

Here we update the version for Heroku CLI dependency to v10.8.0-alpha.0, based on v10.8.0 fixes that were causing an installation failure on MIA.

## Testing

No functional changes done to tools or any other behavior. You can test with the MCP Inspector, though:
```npx @modelcontextprotocol/inspector@latest ./dist/index.js```

## SOC2 Compliance
Slack convo: https://salesforce-internal.slack.com/archives/C048U82QVKQ/p1747947496734449 (Heroku internal).