### PR TITLE
feat: require global install of heroku cli for a4d

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 > The Heroku Platform MCP Server works on Common Runtime, Cedar Private and Shield Spaces, and Fir Private Spaces.
 
+## Prerequisites
+
+- **Heroku CLI** must be installed globally on your system, version **10.8.1 or higher**.
+  - [Install or upgrade the Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
+
 ## Deploy on Heroku
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://www.heroku.com/deploy?template=https://github.com/heroku/heroku-mcp-server)
@@ -23,6 +28,9 @@ Key Features:
 Note: The Heroku Platform MCP Server is currently in early development. As we continue to enhance and refine the
 implementation, the available functionality and tools may evolve. We welcome feedback and contributions to help shape
 the future of this project.
+
+> **Note:** The Heroku Platform MCP Server requires the Heroku CLI to be installed globally (v10.8.1+). Ensure you have
+> the correct version by running `heroku --version`.
 
 ## Authentication
 

--- a/bin/heroku-mcp-server.mjs
+++ b/bin/heroku-mcp-server.mjs
@@ -1,0 +1,9 @@
+/* global process */
+try {
+  const { runServer } = await import('../dist/index.js');
+  await runServer();
+} catch (error) {
+  const { message } = error;
+  process.stderr.write(`Fatal error in main(): ${message}`);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -5,13 +5,12 @@
   "author": "Heroku",
   "bugs": "https://github.com/heroku/heroku-mcp-server/issues",
   "bin": {
-    "heroku-mcp-server": "dist/index.js"
+    "heroku-mcp-server": "bin/heroku-mcp-server.mjs"
   },
   "type": "module",
   "dependencies": {
     "@heroku/plugin-ai": "^1.0.1",
     "@modelcontextprotocol/sdk": "^1.8.0",
-    "heroku": "10.8.0-alpha.0",
     "jsonschema": "^1.5.0",
     "tar-stream": "^3.1.7",
     "zod": "^3.24.2",
@@ -60,7 +59,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "bin"
   ],
   "homepage": "https://github.com/heroku/heroku-mcp-server",
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
     "resolveJsonModule": true,
     "strict": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "bin/**/*"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## 1. Overview

This PR introduces robust startup error handling for the Heroku MCP Server, specifically targeting the initialization of the Heroku CLI REPL which is now required to be installed globally on the user's system. It ensures that fatal errors during startup are surfaced in a standardized MCP error format, improving reliability and debuggability for both users and integrators.

---

## 2. Key Features

- **Standardized Fatal Error Emission:** The `HerokuREPL` now emits a `fatalError` event with a structured MCP error response on startup failures.
- **Detection of Unsupported Heroku CLI Versions:** The server detects and reports if the installed Heroku CLI does not support `--repl` mode.
- **Consistent Error Formatting:** All CLI output, including errors, is now processed through a utility to ensure consistent MCP error formatting.
- **Comprehensive Unit Tests:** New tests cover all startup error scenarios, including process spawn failures, process errors, and unsupported CLI warnings.

---

## 3. Technical Details

- **Implementation:**
  - `HerokuREPL` extends `EventEmitter` and emits a `fatalError` event on startup issues.
  - Startup errors are detected via exceptions, process error events, and CLI output warnings.
  - The new utility `handleCliOutput` formats all error output into a standardized MCP response.
  - The main server (`src/index.ts`) listens for `fatalError` and exits with a clear error message.
- **Error Handling:**
  - Handles process spawn exceptions, process error events, and CLI output indicating unsupported commands.
  - All errors are output as JSON to `stderr` and cause the process to exit with code 1.
- **Configuration:**
  - No new configuration is required. The server continues to respect the `MCP_SERVER_REQUEST_TIMEOUT` environment variable.

---

## 4. Testing Instructions

### Prerequisites

- Node.js 20+
- Heroku CLI installed (test with both supported and unsupported versions)
- Standard build/test environment for this repo
- An understanding of how to setup MCP in a client such as Cursor
- Install v10.8.1-alpha.0 of the Heroku CLI globally. `npm i -g heroku@10.8.1-alpha.0` or similar

### Steps

1. **Build the project:**
   ```sh
   npm install
   npm run build
   ```

2. **Run unit tests:**
   ```sh
   npm test
   ```
   - **Expected:** All tests, including new startup error handling tests, should pass.

3. **Manual error scenario tests:**
   - **Simulate spawn failure:** Temporarily modify the code to throw in the spawn call, or use a test stub.
     - **Expected:** The process emits a `fatalError` event, outputs a JSON MCP error to `stderr`, and exits with code 1.
   - **Simulate unsupported CLI:** Rename or downgrade the Heroku CLI so `heroku --repl` is not recognized.
     - **Expected:** The process emits a `fatalError` event with a message about unsupported `--repl` mode, outputs a JSON MCP error, and exits.
   - **Normal startup:** With a supported CLI, the server should start without emitting `fatalError`.

---

## 5. Impact

- **Improved reliability:** Startup errors are now clearly reported and do not result in silent failures or ambiguous logs.
- **Better user experience:** Users receive actionable, standardized error messages.
- **Easier integration:** Downstream tools and platforms can reliably detect and handle startup failures.
- **Increased test coverage:** New tests ensure robust error handling for future changes.

---

## 6. Future Considerations

- **Graceful recovery:** Consider implementing retry or fallback logic for transient startup errors.
- **CLI version checks:** Proactively check CLI version compatibility before attempting to start the REPL.
- **Enhanced diagnostics:** Include more diagnostic information (e.g., environment, CLI path) in fatal error responses.

---

## 7. Related Documentation

- [Heroku CLI Documentation](https://devcenter.heroku.com/articles/heroku-cli)
- [Node.js Child Process Docs](https://nodejs.org/api/child_process.html)
- [EventEmitter Docs](https://nodejs.org/api/events.html)
- [MCP Tool Response Format](./src/utils/mcp-tool-response.js)
- [Heroku MCP Server README](../README.md)