### PR TITLE
chore: updated config docs to show alternate config using the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can configure Claude Desktop, Zed, Cursor, Windsurf and others to work with 
 ### Primary Configuration: Using `heroku mcp:start` (Heroku CLI v10.8.1+)
 
 Use `heroku mcp:start` to launch the Heroku Platform MCP Server. We recommend this method as it leverages your existing Heroku
-CLI authentication, so you do not need to set the `HEROKU_API_KEY` environment variable. The `heroku mcp:start` command
+CLI authentication, so you don't need to set the [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable. The `heroku mcp:start` command
 is available in Heroku CLI version 10.8.1 and later.
 
 **Benefits:**

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ the future of this project.
 
 You can configure Claude Desktop, Zed, Cursor, Windsurf and others to work with the Heroku Platform MCP Server.
 
-### Primary Configuration: Using `heroku mcp:start` (Heroku CLI v10.8.1+)
+### Configure the Heroku Platform MCP Server with `heroku mcp:start` (Heroku CLI v10.8.1+)
 
 Use `heroku mcp:start` to launch the Heroku Platform MCP Server. We recommend this method as it leverages your existing Heroku
 CLI authentication, so you don't need to set the [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable. The `heroku mcp:start` command

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Heroku CLI authentication, so you don't need to set the
 [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable. The
 `heroku mcp:start` command is available in Heroku CLI version 10.8.1 and later.
 
-There are several benefits to configuring with `heroku mcp:start`:```
+There are several benefits to configuring with `heroku mcp:start`:
 
 - No need to manage or expose your Heroku API key
 - Uses your current Heroku CLI authentication context

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Note: The Heroku Platform MCP Server is currently in early development. As we co
 implementation, the available functionality and tools may evolve. We welcome feedback and contributions to help shape
 the future of this project.
 
-> **Note:** The Heroku Platform MCP Server requires the Heroku CLI to be installed globally (v10.8.1+). Ensure you have
-> the correct version by running `heroku --version`.
+> **Note:** The [Heroku Platform MCP Server](https://devcenter.heroku.com/articles/heroku-mcp-server) requires the
+> Heroku CLI to be installed globally (v10.8.1+). Ensure you have the correct version by running `heroku --version`.
 
 ## Configure the Heroku Platform MCP Server
 
@@ -38,9 +38,10 @@ You can configure Claude Desktop, Zed, Cursor, Windsurf, and other clients to wo
 
 ### Configure the Heroku Platform MCP Server with `heroku mcp:start`
 
-Use `heroku mcp:start` to launch the Heroku Platform MCP Server. We recommend this method as it leverages your existing Heroku
-CLI authentication, so you don't need to set the [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable. The `heroku mcp:start` command
-is available in Heroku CLI version 10.8.1 and later.
+Use `heroku mcp:start` to launch the Heroku Platform MCP Server. We recommend this method as it leverages your existing
+Heroku CLI authentication, so you don't need to set the
+[`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable. The
+`heroku mcp:start` command is available in Heroku CLI version 10.8.1 and later.
 
 There are several benefits to configuring with `heroku mcp:start`:```
 
@@ -140,13 +141,15 @@ There are several benefits to configuring with `heroku mcp:start`:```
 ```
 
 > **Note:** When you use `heroku mcp:start`, the server authenticates using your current Heroku CLI session so you don't
-> need to set the `HEROKU_API_KEY` environment variable. We recommend you use `heroku mcp:start`, but if you prefer to use an API key, you can use the alternate
-> configuration below.
+> need to set the `HEROKU_API_KEY` environment variable. We recommend you use `heroku mcp:start`, but if you prefer to
+> use an API key, you can use the alternate configuration below.
 
 ### Configure the Heroku Platform MCP Server with `npx -y @heroku/mcp-server`
 
 You can also launch the Heroku Platform MCP Server using the `npx -y @heroku/mcp-server` command. This method requires
-you to set the [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable with your Heroku [authorization token](https://devcenter.heroku.com/articles/authentication#retrieving-the-api-token).
+you to set the [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment
+variable with your Heroku
+[authorization token](https://devcenter.heroku.com/articles/authentication#retrieving-the-api-token).
 
 #### Generating the `HEROKU_API_KEY`
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ There are several benefits to configuring with `heroku mcp:start`:```
 
 - No need to manage or expose your Heroku API key
 - Uses your current Heroku CLI authentication context
-- Works seamlessly with all supported clients.
+- Works seamlessly with supported clients
 
 #### Example configuration for [Claude Desktop](https://claude.ai/download):
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can configure Claude Desktop, Zed, Cursor, Windsurf and others to work with 
 
 ### Primary Configuration: Using `heroku mcp:start` (Heroku CLI v10.8.1+)
 
-Use the `heroku mcp:start` command to launch the Heroku Platform MCP Server. This method leverages your existing Heroku
+Use `heroku mcp:start` to launch the Heroku Platform MCP Server. We recommend this method as it leverages your existing Heroku
 CLI authentication, so you do not need to set the `HEROKU_API_KEY` environment variable. The `heroku mcp:start` command
 is available in Heroku CLI version 10.8.1 and later.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ is available in Heroku CLI version 10.8.1 and later.
 There are several benefits to configuring with `heroku mcp:start`:```
 
 - No need to manage or expose your Heroku API key
-- Uses your current Heroku CLI authentication context.
+- Uses your current Heroku CLI authentication context
 - Works seamlessly with all supported clients.
 
 #### Example configuration for [Claude Desktop](https://claude.ai/download):

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ There are several benefits to configuring with `heroku mcp:start`:```
 ```
 
 > **Note:** When you use `heroku mcp:start`, the server authenticates using your current Heroku CLI session so you don't
-> need to set the `HEROKU_API_KEY` environment variable. If you prefer to use an API key, you can use the alternate
+> need to set the `HEROKU_API_KEY` environment variable. We recommend you use `heroku mcp:start`, but if you prefer to use an API key, you can use the alternate
 > configuration below.
 
 ### Configure the Heroku Platform MCP Server with `npx -y @heroku/mcp-server`

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ There are several benefits to configuring with `heroku mcp:start`:```
 ### Configure the Heroku Platform MCP Server with `npx -y @heroku/mcp-server`
 
 You can also launch the Heroku Platform MCP Server using the `npx -y @heroku/mcp-server` command. This method requires
-you to set the [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable with your Heroku authorization token.
+you to set the [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable with your Heroku [authorization token](https://devcenter.heroku.com/articles/authentication#retrieving-the-api-token).
 
 #### Generating the `HEROKU_API_KEY`
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Use `heroku mcp:start` to launch the Heroku Platform MCP Server. We recommend th
 CLI authentication, so you don't need to set the [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable. The `heroku mcp:start` command
 is available in Heroku CLI version 10.8.1 and later.
 
-**Benefits:**
+There are several benefits to configuring with `heroku mcp:start`:```
 
 - No need to manage or expose your Heroku API key.
 - Uses your current Heroku CLI authentication context.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ is available in Heroku CLI version 10.8.1 and later.
 > need to set the `HEROKU_API_KEY` environment variable. If you prefer to use an API key, you can use the alternate
 > configuration below.
 
-### Alternate Configuration: Using `npx -y @heroku/mcp-server`
+### Configure the Heroku Platform MCP Server with `npx -y @heroku/mcp-server`
 
 You can also launch the Heroku Platform MCP Server using the `npx -y @heroku/mcp-server` command. This method requires
 you to set the `HEROKU_API_KEY` environment variable with your Heroku authorization token.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ There are several benefits to configuring with `heroku mcp:start`:```
 }
 ```
 
-> **Note:** When you use `heroku mcp:start`, the server authenticates using your current Heroku CLI session. You do not
+> **Note:** When you use `heroku mcp:start`, the server authenticates using your current Heroku CLI session so you don't
 > need to set the `HEROKU_API_KEY` environment variable. If you prefer to use an API key, you can use the alternate
 > configuration below.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,123 @@ the future of this project.
 > **Note:** The Heroku Platform MCP Server requires the Heroku CLI to be installed globally (v10.8.1+). Ensure you have
 > the correct version by running `heroku --version`.
 
-## Authentication
+## Configure the Heroku Platform MCP Server
+
+You can configure Claude Desktop, Zed, Cursor, Windsurf and others to work with the Heroku Platform MCP Server.
+
+### Primary Configuration: Using `heroku mcp:start` (Heroku CLI v10.8.1+)
+
+Use the `heroku mcp:start` command to launch the Heroku Platform MCP Server. This method leverages your existing Heroku
+CLI authentication, so you do not need to set the `HEROKU_API_KEY` environment variable. The `heroku mcp:start` command
+is available in Heroku CLI version 10.8.1 and later.
+
+**Benefits:**
+
+- No need to manage or expose your Heroku API key.
+- Uses your current Heroku CLI authentication context.
+- Works seamlessly with all supported clients.
+
+#### Example configuration for [Claude Desktop](https://claude.ai/download):
+
+```json
+{
+  "mcpServers": {
+    "heroku": {
+      "command": "heroku mcp:start"
+    }
+  }
+}
+```
+
+#### Example configuration for [Zed](https://github.com/zed-industries/zed):
+
+```json
+{
+  "context_servers": {
+    "heroku": {
+      "command": {
+        "path": "heroku",
+        "args": ["mcp:start"]
+      }
+    }
+  }
+}
+```
+
+#### Example configuration for [Cursor](https://www.cursor.com/):
+
+```json
+{
+  "mcpServers": {
+    "heroku": {
+      "command": "heroku mcp:start"
+    }
+  }
+}
+```
+
+#### Example configuration for [Windsurf](https://www.windsurf.com/):
+
+```json
+{
+  "mcpServers": {
+    "heroku": {
+      "command": "heroku mcp:start"
+    }
+  }
+}
+```
+
+#### Example configuration for [Cline](https://cline.bot):
+
+```json
+{
+  "mcpServers": {
+    "heroku": {
+      "command": "heroku mcp:start"
+    }
+  }
+}
+```
+
+#### Example configuration for [VSCode](https://code.visualstudio.com/):
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "heroku": {
+        "type": "stdio",
+        "command": "heroku",
+        "args": ["mcp:start"]
+      }
+    }
+  }
+}
+```
+
+#### Example configuration for [Trae](https://trae.ai):
+
+```json
+{
+  "mcpServers": {
+    "heroku": {
+      "command": "heroku mcp:start"
+    }
+  }
+}
+```
+
+> **Note:** When you use `heroku mcp:start`, the server authenticates using your current Heroku CLI session. You do not
+> need to set the `HEROKU_API_KEY` environment variable. If you prefer to use an API key, you can use the alternate
+> configuration below.
+
+### Alternate Configuration: Using `npx -y @heroku/mcp-server`
+
+You can also launch the Heroku Platform MCP Server using the `npx -y @heroku/mcp-server` command. This method requires
+you to set the `HEROKU_API_KEY` environment variable with your Heroku authorization token.
+
+#### Generating the `HEROKU_API_KEY`
 
 Generate a Heroku authorization token with one of these methods:
 
@@ -55,13 +171,7 @@ Generate a Heroku authorization token with one of these methods:
   2. Open the Applications tab.
   3. Next to **Authorizations**, click **Create authorization**.
 
-## Configure the Heroku Platform MCP Server
-
-You can configure Claude Desktop, Zed, Cursor, Windsurf and others to work with the Heroku Platform MCP Server.
-
-### [Claude Desktop](https://claude.ai/download)
-
-Add this snippet to your `claude_desktop_config.json`:
+#### Example configuration for [Claude Desktop](https://claude.ai/download):
 
 ```json
 {
@@ -77,9 +187,7 @@ Add this snippet to your `claude_desktop_config.json`:
 }
 ```
 
-### [Zed](https://github.com/zed-industries/zed)
-
-Add this snippet to your Zed `settings.json`:
+#### Example configuration for [Zed](https://github.com/zed-industries/zed):
 
 ```json
 {
@@ -97,14 +205,7 @@ Add this snippet to your Zed `settings.json`:
 }
 ```
 
-### [Cursor](https://www.cursor.com/)
-
-> **Note:** Both the simple and explicit forms work, but the key should be `"heroku"` (not `"heroku-mcp-server"`) for
-> maximum compatibility with agent tools.
-
-Add this snippet to your Cursor `mcp.json`:
-
-**Simple form:**
+#### Example configuration for [Cursor](https://www.cursor.com/):
 
 ```json
 {
@@ -119,7 +220,7 @@ Add this snippet to your Cursor `mcp.json`:
 }
 ```
 
-**Explicit form:**
+#### Example configuration for [Windsurf](https://www.windsurf.com/):
 
 ```json
 {
@@ -135,9 +236,7 @@ Add this snippet to your Cursor `mcp.json`:
 }
 ```
 
-### [Windsurf](https://www.windsurf.com/)
-
-Add this snippet to your Windsurf `mcp_config.json`:
+#### Example configuration for [Cline](https://cline.bot):
 
 ```json
 {
@@ -153,27 +252,7 @@ Add this snippet to your Windsurf `mcp_config.json`:
 }
 ```
 
-### [Cline](https://cline.bot)
-
-Add this snippet to your Cline `config.json`:
-
-```json
-{
-  "mcpServers": {
-    "heroku": {
-      "command": "npx",
-      "args": ["-y", "@heroku/mcp-server"],
-      "env": {
-        "HEROKU_API_KEY": "<YOUR_HEROKU_AUTH_TOKEN>"
-      }
-    }
-  }
-}
-```
-
-### [VSCode](https://code.visualstudio.com/)
-
-Add this snippet to your VSCode `settings.json` or `.vscode/mcp.json`:
+#### Example configuration for [VSCode](https://code.visualstudio.com/):
 
 ```json
 {
@@ -192,9 +271,7 @@ Add this snippet to your VSCode `settings.json` or `.vscode/mcp.json`:
 }
 ```
 
-### [Trae](https://trae.ai)
-
-Add this snippet to your Trae `mcp_settings.json`:
+#### Example configuration for [Trae](https://trae.ai):
 
 ```json
 {
@@ -209,6 +286,9 @@ Add this snippet to your Trae `mcp_settings.json`:
   }
 }
 ```
+
+> **Note:** When you use `npx -y @heroku/mcp-server`, you must set the `HEROKU_API_KEY` environment variable with your
+> Heroku authorization token.
 
 ## Available Tools
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ There are several benefits to configuring with `heroku mcp:start`:```
 ### Configure the Heroku Platform MCP Server with `npx -y @heroku/mcp-server`
 
 You can also launch the Heroku Platform MCP Server using the `npx -y @heroku/mcp-server` command. This method requires
-you to set the `HEROKU_API_KEY` environment variable with your Heroku authorization token.
+you to set the [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable with your Heroku authorization token.
 
 #### Generating the `HEROKU_API_KEY`
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ the future of this project.
 
 You can configure Claude Desktop, Zed, Cursor, Windsurf, and other clients to work with the Heroku Platform MCP Server.
 
-### Configure the Heroku Platform MCP Server with `heroku mcp:start` (Heroku CLI v10.8.1+)
+### Configure the Heroku Platform MCP Server with `heroku mcp:start`
 
 Use `heroku mcp:start` to launch the Heroku Platform MCP Server. We recommend this method as it leverages your existing Heroku
 CLI authentication, so you don't need to set the [`HEROKU_API_KEY`](https://devcenter.heroku.com/articles/heroku-mcp-server#authentication) environment variable. The `heroku mcp:start` command

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ is available in Heroku CLI version 10.8.1 and later.
 
 There are several benefits to configuring with `heroku mcp:start`:```
 
-- No need to manage or expose your Heroku API key.
+- No need to manage or expose your Heroku API key
 - Uses your current Heroku CLI authentication context.
 - Works seamlessly with all supported clients.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ the future of this project.
 
 ## Configure the Heroku Platform MCP Server
 
-You can configure Claude Desktop, Zed, Cursor, Windsurf and others to work with the Heroku Platform MCP Server.
+You can configure Claude Desktop, Zed, Cursor, Windsurf, and other clients to work with the Heroku Platform MCP Server.
 
 ### Configure the Heroku Platform MCP Server with `heroku mcp:start` (Heroku CLI v10.8.1+)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -848,10 +848,11 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -915,10 +916,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1313,10 +1315,11 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4379,9 +4382,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -6275,10 +6279,11 @@
       }
     },
     "node_modules/eslint-config-salesforce-typescript/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6604,10 +6609,11 @@
       }
     },
     "node_modules/eslint-config-salesforce-typescript/node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6821,10 +6827,11 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6954,10 +6961,11 @@
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7048,10 +7056,11 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7892,10 +7901,11 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9525,9 +9535,9 @@
       }
     },
     "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -13007,9 +13017,9 @@
       }
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13956,10 +13966,11 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"


### PR DESCRIPTION
## Add Alternate Configuration for `heroku mcp:start` (Heroku CLI v10.8.1+) to README

### What’s Changed

- **Added a new section** to the README that documents how to configure the Heroku Platform MCP Server using the `heroku mcp:start` command, available in Heroku CLI v10.8.1 and later.
- **Provided example configuration snippets** for all supported clients (Claude Desktop, Zed, Cursor, Windsurf, Cline, VSCode, Trae) using the `heroku mcp:start` command.
- **Clarified that `HEROKU_API_KEY` is optional** when using this method, as authentication is handled by the current Heroku CLI session.
- **Outlined the benefits** of this approach, including improved security and ease of use.
- **Added a note** explaining when to use each method (`heroku mcp:start` vs. `npx -y @heroku/mcp-server`).

### Why

- Makes it easier for users to securely configure the MCP server without managing API keys.
- Documents new functionality available in Heroku CLI v10.8.1+.
- Improves clarity and user experience by following Heroku’s voice and tone guidelines.