### PR TITLE
Release v1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heroku/mcp-server",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heroku/mcp-server",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/plugin-ai": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@heroku/mcp-server",
   "description": "Heroku Platform MCP Server",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Heroku",
   "bugs": "https://github.com/heroku/heroku-mcp-server/issues",
   "bin": {


### PR DESCRIPTION
Version bump for v1.0.7 release

This PR contains the version bump commit created by `npm version patch` during the release process.

Changes:
- Updates package.json version from 1.0.6 to 1.0.7
- Published to NPM: https://www.npmjs.com/package/@heroku/mcp-server
- Git tag v1.0.7 created and pushed

This is a patch release with bug fixes and minor updates.