### PR TITLE
Mm/feat/integrate sdk refactor addons tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1359,7 +1359,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.4.0",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#20dbe314ea00d057b26b329f5b47736f26821503",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#efce1d4fffd1be97127f4fe78bc65b1e22d6d0de",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "github:heroku/heroku-fetch",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@heroku-cli/schema": "^2.0.1",
         "@heroku/sdk": "github:heroku/heroku-sdk#main",
-        "@heroku/types": "github:heroku/heroku-types",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "cheerio": "^1.2.0",
         "jsonschema": "^1.5.0",
@@ -27,6 +26,7 @@
         "@anthropic-ai/mcpb": "^2.1.2",
         "@eslint/eslintrc": "^3.3.3",
         "@eslint/js": "^9.39.2",
+        "@heroku/types": "github:heroku/heroku-types#main",
         "@types/chai": "^5.2.1",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.x",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "^2.1.2",
-    "@heroku/types": "github:heroku/heroku-types#main",
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.39.2",
+    "@heroku/types": "github:heroku/heroku-types#main",
     "@types/chai": "^5.2.1",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.x",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import * as devCenterResource from './resources/dev-center-resource.js';
 import { HerokuREPL } from './repl/heroku-cli-repl.js';
 import { isPluginInstalled } from './utils/plugin-detector.js';
 import { HerokuSDK } from '@heroku/sdk';
-import { appExtensions } from '@heroku/sdk/extensions/platform';
+import { addOnExtensions, appExtensions } from '@heroku/sdk/extensions/platform';
 
 const VERSION = pjson.default.version;
 
@@ -38,7 +38,7 @@ const requestTimeout = isNaN(Number(process.env.MCP_SERVER_REQUEST_TIMEOUT))
   : Number(process.env.MCP_SERVER_REQUEST_TIMEOUT);
 const herokuRepl = new HerokuREPL(requestTimeout);
 
-const herokuSdk = new HerokuSDK({ extensions: [appExtensions] });
+const herokuSdk = new HerokuSDK({ extensions: [addOnExtensions, appExtensions] });
 
 const appSdk: apps.AppSdk = {
   list: () => herokuSdk.platform.app.list(),
@@ -53,6 +53,15 @@ const appSdk: apps.AppSdk = {
 const maintenanceSdk: maintenance.MaintenanceSdk = {
   enableMaintenance: (appIdentity) => herokuSdk.platform.app.enableMaintenance(appIdentity),
   disableMaintenance: (appIdentity) => herokuSdk.platform.app.disableMaintenance(appIdentity)
+};
+
+const addonSdk: addons.AddonSdk = {
+  list: () => herokuSdk.platform.addOn.list(),
+  listByApp: (appIdentity) => herokuSdk.platform.addOn.listByApp(appIdentity),
+  describe: (addonIdentity, options) => herokuSdk.platform.addOn.describe(addonIdentity, options),
+  create: (appIdentity, body) => herokuSdk.platform.addOn.create(appIdentity, body),
+  listServices: () => herokuSdk.platform.addOnService.list(),
+  listPlans: (serviceIdentity) => herokuSdk.platform.addOn.listPlans(serviceIdentity)
 };
 
 // Listen for MCP-formatted fatal startup errors
@@ -81,11 +90,11 @@ spaces.registerListPrivateSpacesTool(server, herokuRepl);
 teams.registerListTeamsTool(server, herokuRepl);
 
 // Add-on related tools
-addons.registerListAddonsTool(server, herokuRepl);
-addons.registerGetAddonInfoTool(server, herokuRepl);
-addons.registerCreateAddonTool(server, herokuRepl);
-addons.registerListAddonServicesTool(server, herokuRepl);
-addons.registerListAddonPlansTool(server, herokuRepl);
+addons.registerListAddonsTool(server, addonSdk);
+addons.registerGetAddonInfoTool(server, addonSdk);
+addons.registerCreateAddonTool(server, addonSdk);
+addons.registerListAddonServicesTool(server, addonSdk);
+addons.registerListAddonPlansTool(server, addonSdk);
 
 // PostgreSQL-related tools
 data.registerPgPsqlTool(server, herokuRepl);

--- a/src/tools/addons.spec.ts
+++ b/src/tools/addons.spec.ts
@@ -10,25 +10,44 @@ import {
   registerGetAddonInfoTool,
   registerCreateAddonTool,
   registerListAddonServicesTool,
-  registerListAddonPlansTool
+  registerListAddonPlansTool,
+  AddonSdk
 } from './addons.js';
-import { CommandBuilder } from '../utils/command-builder.js';
-import { TOOL_COMMAND_MAP } from '../utils/tool-commands.js';
 import { setupMcpToolMocks } from '../utils/mcp-tool-mocks.spechelper.js';
 
 describe('addons topic tools', () => {
+  let sdk: {
+    list: sinon.SinonStub;
+    listByApp: sinon.SinonStub;
+    describe: sinon.SinonStub;
+    create: sinon.SinonStub;
+    listServices: sinon.SinonStub;
+    listPlans: sinon.SinonStub;
+  };
+
+  beforeEach(() => {
+    sdk = {
+      list: sinon.stub(),
+      listByApp: sinon.stub(),
+      describe: sinon.stub(),
+      create: sinon.stub(),
+      listServices: sinon.stub(),
+      listPlans: sinon.stub()
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('registerListAddonsTool', () => {
     let mocks: ReturnType<typeof setupMcpToolMocks>;
     let toolCallback: Function;
 
     beforeEach(() => {
       mocks = setupMcpToolMocks();
-      registerListAddonsTool(mocks.server, mocks.herokuRepl);
+      registerListAddonsTool(mocks.server, sdk as AddonSdk);
       toolCallback = mocks.getToolCallback();
-    });
-
-    afterEach(() => {
-      sinon.restore();
     });
 
     it('registers the tool with correct name and schema', () => {
@@ -38,38 +57,35 @@ describe('addons topic tools', () => {
       expect(call.args[2]).to.deep.equal(listAddonsOptionsSchema.shape);
     });
 
-    it('executes command successfully with all flag', async () => {
-      const expectedOutput =
-        ' Owning app Add-on                  Plan                          Price        Max price State   \n' +
-        ' ────────── ─────────────────────── ───────────────────────────── ──────────── ───────── ─────── \n' +
-        ' test-app   postgresql-curved-12345 heroku-postgresql:essential-0 ~$0.007/hour $5/month  created \n' +
-        ' test-app-2 redis-elliptical-12345  heroku-redis:mini             ~$0.004/hour $3/month  created \n';
-      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.LIST_ADDONS).addFlags({ all: true }).build();
+    it('calls sdk.list by default', async () => {
+      const addons = [{ name: 'postgresql-curved-12345' }, { name: 'redis-elliptical-67890' }];
+      sdk.list.resolves(addons);
 
-      mocks.herokuRepl.executeCommand.resolves(expectedOutput);
-
-      const result = await toolCallback({ all: true }, {});
-      expect(mocks.herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
+      const result = await toolCallback({});
+      expect(sdk.list.calledOnce).to.be.true;
       expect(result).to.deep.equal({
-        content: [{ type: 'text', text: expectedOutput }]
+        content: [{ type: 'text', text: JSON.stringify(addons, null, 2) }]
       });
     });
 
-    it('executes command successfully with app flag', async () => {
-      const expectedOutput =
-        ' Add-on                                Plan Price        Max price State   \n' +
-        ' ───────────────────────────────────── ──── ──────────── ───────── ─────── \n' +
-        ' heroku-redis (redis-elliptical-12345) mini ~$0.004/hour $3/month  created \n' +
-        '  └─ as REDIS_TEST_DB                                                      \n';
-      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.LIST_ADDONS).addFlags({ app: 'test-app-2' }).build();
+    it('calls sdk.listByApp when app provided', async () => {
+      const addons = [{ name: 'postgresql-curved-12345' }];
+      sdk.listByApp.resolves(addons);
 
-      mocks.herokuRepl.executeCommand.resolves(expectedOutput);
-
-      const result = await toolCallback({ app: 'test-app-2' }, {});
-      expect(mocks.herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
+      const result = await toolCallback({ app: 'my-app' });
+      expect(sdk.listByApp.calledOnceWith('my-app')).to.be.true;
       expect(result).to.deep.equal({
-        content: [{ type: 'text', text: expectedOutput }]
+        content: [{ type: 'text', text: JSON.stringify(addons, null, 2) }]
       });
+    });
+
+    it('handles error response', async () => {
+      sdk.list.rejects(new Error('401: Unauthorized'));
+
+      const result = await toolCallback({});
+      expect(result.isError).to.be.true;
+      expect(result.content[0].text).to.include('[Heroku MCP Server Error]');
+      expect(result.content[0].text).to.include('401: Unauthorized');
     });
   });
 
@@ -79,12 +95,8 @@ describe('addons topic tools', () => {
 
     beforeEach(() => {
       mocks = setupMcpToolMocks();
-      registerGetAddonInfoTool(mocks.server, mocks.herokuRepl);
+      registerGetAddonInfoTool(mocks.server, sdk as AddonSdk);
       toolCallback = mocks.getToolCallback();
-    });
-
-    afterEach(() => {
-      sinon.restore();
     });
 
     it('registers the tool with correct name and schema', () => {
@@ -94,43 +106,34 @@ describe('addons topic tools', () => {
       expect(call.args[2]).to.deep.equal(getAddonInfoOptionsSchema.shape);
     });
 
-    it('executes command successfully with add-on name', async () => {
-      const expectedOutput =
-        '=== postgresql-curved-12345\n\n' +
-        'Attachments: test-app::DATABASE\n' +
-        'Owning App:  test-app\n' +
-        'Plan:        heroku-postgresql:essential-0\n';
-      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.GET_ADDON_INFO)
-        .addPositionalArguments({ addon: 'postgresql-curved-12345' })
-        .build();
+    it('calls sdk.describe with addon identity', async () => {
+      const addon = { name: 'postgresql-curved-12345', plan: { name: 'essential-0' }, attachments: [] };
+      sdk.describe.resolves(addon);
 
-      mocks.herokuRepl.executeCommand.resolves(expectedOutput);
-
-      const result = await toolCallback({ addon: 'postgresql-curved-12345' }, {});
-      expect(mocks.herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
+      const result = await toolCallback({ addon: 'postgresql-curved-12345' });
+      expect(sdk.describe.calledOnceWith('postgresql-curved-12345', { appIdentity: undefined })).to.be.true;
       expect(result).to.deep.equal({
-        content: [{ type: 'text', text: expectedOutput }]
+        content: [{ type: 'text', text: JSON.stringify(addon, null, 2) }]
       });
     });
 
-    it('executes command successfully with app context', async () => {
-      const expectedOutput =
-        '=== postgresql-curved-12345\n\n' +
-        'Attachments: test-app::DATABASE\n' +
-        'Owning App:  test-app\n' +
-        'Plan:        heroku-postgresql:essential-0\n';
-      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.GET_ADDON_INFO)
-        .addPositionalArguments({ addon: 'DATABASE' })
-        .addFlags({ app: 'test-app' })
-        .build();
+    it('calls sdk.describe with addon and app context', async () => {
+      const addon = { name: 'postgresql-curved-12345', plan: { name: 'essential-0' }, attachments: [] };
+      sdk.describe.resolves(addon);
 
-      mocks.herokuRepl.executeCommand.resolves(expectedOutput);
-
-      const result = await toolCallback({ addon: 'DATABASE', app: 'test-app' }, {});
-      expect(mocks.herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
+      const result = await toolCallback({ addon: 'DATABASE', app: 'my-app' });
+      expect(sdk.describe.calledOnceWith('DATABASE', { appIdentity: 'my-app' })).to.be.true;
       expect(result).to.deep.equal({
-        content: [{ type: 'text', text: expectedOutput }]
+        content: [{ type: 'text', text: JSON.stringify(addon, null, 2) }]
       });
+    });
+
+    it('handles error response', async () => {
+      sdk.describe.rejects(new Error('404: Not Found'));
+
+      const result = await toolCallback({ addon: 'nonexistent' });
+      expect(result.isError).to.be.true;
+      expect(result.content[0].text).to.include('404: Not Found');
     });
   });
 
@@ -140,12 +143,8 @@ describe('addons topic tools', () => {
 
     beforeEach(() => {
       mocks = setupMcpToolMocks();
-      registerCreateAddonTool(mocks.server, mocks.herokuRepl);
+      registerCreateAddonTool(mocks.server, sdk as AddonSdk);
       toolCallback = mocks.getToolCallback();
-    });
-
-    afterEach(() => {
-      sinon.restore();
     });
 
     it('registers the tool with correct name and schema', () => {
@@ -155,60 +154,55 @@ describe('addons topic tools', () => {
       expect(call.args[2]).to.deep.equal(createAddonOptionsSchema.shape);
     });
 
-    it('executes command successfully with all options', async () => {
-      const expectedOutput =
-        'Creating heroku-postgresql:essential-0 on test-app... ~$0.007/hour (max $5/month)\n' +
-        'Database should be available soon\n' +
-        'test-app-primary-db is being created in the background. The app will restart when complete...\n';
-      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.CREATE_ADDON)
-        .addFlags({
-          app: 'test-app',
-          as: 'DATABASE',
-          name: 'test-app-primary-db'
+    it('calls sdk.create with all options', async () => {
+      const addon = { name: 'my-db', plan: { name: 'heroku-postgresql:essential-0' } };
+      sdk.create.resolves(addon);
+
+      const result = await toolCallback({
+        app: 'my-app',
+        plan: 'heroku-postgresql:essential-0',
+        as: 'DATABASE',
+        name: 'my-db'
+      });
+      expect(
+        sdk.create.calledOnceWith('my-app', {
+          plan: 'heroku-postgresql:essential-0',
+          attachment: { name: 'DATABASE' },
+          name: 'my-db'
         })
-        .addPositionalArguments({ 'service:plan': 'heroku-postgresql:essential-0' })
-        .build();
-
-      mocks.herokuRepl.executeCommand.resolves(expectedOutput);
-
-      const result = await toolCallback(
-        {
-          app: 'test-app',
-          as: 'DATABASE',
-          name: 'test-app-primary-db',
-          serviceAndPlan: 'heroku-postgresql:essential-0'
-        },
-        {}
-      );
-      expect(mocks.herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
+      ).to.be.true;
       expect(result).to.deep.equal({
-        content: [{ type: 'text', text: expectedOutput }]
+        content: [{ type: 'text', text: JSON.stringify(addon, null, 2) }]
       });
     });
 
-    it('executes command successfully with minimal options', async () => {
-      const expectedOutput =
-        'Creating heroku-postgresql:essential-0 on test-app... ~$0.007/hour (max $5/month)\n' +
-        'Database should be available soon\n' +
-        'postgresql-curved-12345 is being created in the background. The app will restart when complete...\n';
-      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.CREATE_ADDON)
-        .addFlags({ app: 'test-app' })
-        .addPositionalArguments({ 'service:plan': 'heroku-postgresql:essential-0' })
-        .build();
+    it('calls sdk.create with minimal options', async () => {
+      const addon = { name: 'postgresql-curved-12345' };
+      sdk.create.resolves(addon);
 
-      mocks.herokuRepl.executeCommand.resolves(expectedOutput);
-
-      const result = await toolCallback(
-        {
-          app: 'test-app',
-          serviceAndPlan: 'heroku-postgresql:essential-0'
-        },
-        {}
-      );
-      expect(mocks.herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
-      expect(result).to.deep.equal({
-        content: [{ type: 'text', text: expectedOutput }]
+      const result = await toolCallback({
+        app: 'my-app',
+        plan: 'heroku-postgresql:essential-0'
       });
+      expect(
+        sdk.create.calledOnceWith('my-app', {
+          plan: 'heroku-postgresql:essential-0'
+        })
+      ).to.be.true;
+      expect(result).to.deep.equal({
+        content: [{ type: 'text', text: JSON.stringify(addon, null, 2) }]
+      });
+    });
+
+    it('handles error response', async () => {
+      sdk.create.rejects(new Error('422: Name is already taken'));
+
+      const result = await toolCallback({
+        app: 'my-app',
+        plan: 'heroku-postgresql:essential-0'
+      });
+      expect(result.isError).to.be.true;
+      expect(result.content[0].text).to.include('422: Name is already taken');
     });
   });
 
@@ -218,12 +212,8 @@ describe('addons topic tools', () => {
 
     beforeEach(() => {
       mocks = setupMcpToolMocks();
-      registerListAddonServicesTool(mocks.server, mocks.herokuRepl);
+      registerListAddonServicesTool(mocks.server, sdk as AddonSdk);
       toolCallback = mocks.getToolCallback();
-    });
-
-    afterEach(() => {
-      sinon.restore();
     });
 
     it('registers the tool with correct name and schema', () => {
@@ -233,20 +223,26 @@ describe('addons topic tools', () => {
       expect(call.args[2]).to.deep.equal(listAddonServicesOptionsSchema.shape);
     });
 
-    it('executes command successfully', async () => {
-      const expectedOutput =
-        ' Slug              Name                   State \n' +
-        ' ───────────────── ────────────────────── ───── \n' +
-        ' heroku-postgresql Heroku PostgreSQL      ga    \n' +
-        ' heroku-redis      Heroku Key-Value Store ga    \n';
-      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.LIST_ADDON_SERVICES).build();
-      mocks.herokuRepl.executeCommand.resolves(expectedOutput);
+    it('calls sdk.listServices', async () => {
+      const services = [
+        { name: 'Heroku PostgreSQL', slug: 'heroku-postgresql' },
+        { name: 'Heroku Key-Value Store', slug: 'heroku-redis' }
+      ];
+      sdk.listServices.resolves(services);
 
-      const result = await toolCallback({}, {});
-      expect(mocks.herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
+      const result = await toolCallback({});
+      expect(sdk.listServices.calledOnce).to.be.true;
       expect(result).to.deep.equal({
-        content: [{ type: 'text', text: expectedOutput }]
+        content: [{ type: 'text', text: JSON.stringify(services, null, 2) }]
       });
+    });
+
+    it('handles error response', async () => {
+      sdk.listServices.rejects(new Error('500: Internal Server Error'));
+
+      const result = await toolCallback({});
+      expect(result.isError).to.be.true;
+      expect(result.content[0].text).to.include('500: Internal Server Error');
     });
   });
 
@@ -256,12 +252,8 @@ describe('addons topic tools', () => {
 
     beforeEach(() => {
       mocks = setupMcpToolMocks();
-      registerListAddonPlansTool(mocks.server, mocks.herokuRepl);
+      registerListAddonPlansTool(mocks.server, sdk as AddonSdk);
       toolCallback = mocks.getToolCallback();
-    });
-
-    afterEach(() => {
-      sinon.restore();
     });
 
     it('registers the tool with correct name and schema', () => {
@@ -271,72 +263,26 @@ describe('addons topic tools', () => {
       expect(call.args[2]).to.deep.equal(listAddonPlansOptionsSchema.shape);
     });
 
-    it('executes command successfully', async () => {
-      const expectedOutput =
-        '         Slug                           Name         Price         Max price    \n' +
-        ' ─────── ────────────────────────────── ──────────── ───────────── ──────────── \n' +
-        ' default heroku-postgresql:essential-0  Essential 0  ~$0.007/hour  $5/month     \n' +
-        '         heroku-postgresql:essential-1  Essential 1  ~$0.013/hour  $9/month     \n';
-      const expectedCommand = new CommandBuilder(TOOL_COMMAND_MAP.LIST_ADDON_PLANS)
-        .addPositionalArguments({ service: 'heroku-postgresql' })
-        .build();
-      mocks.herokuRepl.executeCommand.resolves(expectedOutput);
+    it('calls sdk.listPlans with service', async () => {
+      const plans = [
+        { name: 'essential-0', price: { cents: 500, unit: 'month' } },
+        { name: 'essential-1', price: { cents: 900, unit: 'month' } }
+      ];
+      sdk.listPlans.resolves(plans);
 
-      const result = await toolCallback({ service: 'heroku-postgresql' }, {});
-      expect(mocks.herokuRepl.executeCommand.calledOnceWith(expectedCommand)).to.be.true;
+      const result = await toolCallback({ service: 'heroku-postgresql' });
+      expect(sdk.listPlans.calledOnceWith('heroku-postgresql')).to.be.true;
       expect(result).to.deep.equal({
-        content: [{ type: 'text', text: expectedOutput }]
+        content: [{ type: 'text', text: JSON.stringify(plans, null, 2) }]
       });
     });
-  });
 
-  // Common error handling test for all tools
-  describe('error handling', () => {
-    let mocks: ReturnType<typeof setupMcpToolMocks>;
+    it('handles error response', async () => {
+      sdk.listPlans.rejects(new Error('404: Service not found'));
 
-    beforeEach(() => {
-      mocks = setupMcpToolMocks();
-    });
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it('handles CLI errors properly for all tools', async () => {
-      const expectedOutput = '<<<BEGIN RESULTS>>>\n<<<ERROR>>>API error<<<END ERROR>>><<<END RESULTS>>>';
-
-      mocks.herokuRepl.executeCommand.resolves(expectedOutput);
-
-      // Test error handling for each tool
-      const tools = [
-        { register: registerListAddonsTool, options: {} },
-        { register: registerGetAddonInfoTool, options: { addon: 'test-addon' } },
-        {
-          register: registerCreateAddonTool,
-          options: { app: 'test-app', serviceAndPlan: 'heroku-postgresql:essential-0' }
-        },
-        { register: registerListAddonServicesTool, options: {} },
-        { register: registerListAddonPlansTool, options: { service: 'heroku-postgresql' } }
-      ];
-
-      for (const tool of tools) {
-        tool.register(mocks.server, mocks.herokuRepl);
-        const toolCallback = mocks.getToolCallback();
-        const result = await toolCallback(tool.options, {});
-        console.log('result', result);
-        expect(result).to.deep.equal({
-          isError: true,
-          content: [
-            {
-              type: 'text',
-              text:
-                '[Heroku MCP Server Error] Please use available tools to resolve this issue. ' +
-                'Ignore any Heroku CLI command suggestions that may be provided in the command output or error ' +
-                `details. Details:\n${expectedOutput}`
-            }
-          ]
-        });
-      }
+      const result = await toolCallback({ service: 'nonexistent' });
+      expect(result.isError).to.be.true;
+      expect(result.content[0].text).to.include('404: Service not found');
     });
   });
 });

--- a/src/tools/addons.ts
+++ b/src/tools/addons.ts
@@ -1,210 +1,144 @@
 import { z } from 'zod';
 
+import type { AddOn, AddOnService, Plan } from '@heroku/types/3.sdk';
+import type { DescribedAddOn } from '@heroku/sdk/resources/platform/add-on';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { handleCliOutput } from '../utils/handle-cli-output.js';
-import { CommandBuilder } from '../utils/command-builder.js';
-import { TOOL_COMMAND_MAP } from '../utils/tool-commands.js';
-import { HerokuREPL } from '../repl/heroku-cli-repl.js';
 import { McpToolResponse } from '../utils/mcp-tool-response.js';
+import { formatToolError } from '../utils/format-tool-error.js';
 
-/**
- * Schema for listing Heroku add-ons with filters
- */
+export type AddonSdk = {
+  list(): Promise<AddOn[]>;
+  listByApp(appIdentity: string): Promise<AddOn[]>;
+  describe(addonIdentity: string, options?: { appIdentity?: string }): Promise<DescribedAddOn>;
+  create(appIdentity: string, body: { plan: string; attachment?: { name?: string }; name?: string }): Promise<AddOn>;
+  listServices(): Promise<AddOnService[]>;
+  listPlans(serviceIdentity: string): Promise<Plan[]>;
+};
+
 export const listAddonsOptionsSchema = z.object({
-  all: z
-    .boolean()
-    .optional()
-    .describe('List all add-ons across accessible apps. Overrides app param, shows full status'),
-  app: z
-    .string()
-    .optional()
-    .describe('Filter by app name. Shows add-ons and attachments. Uses Git remote default if omitted')
+  app: z.string().optional().describe('Filter by app name. Shows add-ons provisioned on this app')
 });
 
-/**
- * Type definition for the options used when listing Heroku add-ons.
- */
 export type ListAddonsOptions = z.infer<typeof listAddonsOptionsSchema>;
 
-/**
- * Registers the list_addons tool with the MCP server.
- *
- * @param server - The MCP server instance to register the tool with
- * @param herokuRepl - The Heroku REPL instance for executing commands
- */
-export const registerListAddonsTool = (server: McpServer, herokuRepl: HerokuREPL): void => {
+export const registerListAddonsTool = (server: McpServer, sdk: AddonSdk): void => {
   server.tool(
     'list_addons',
-    'List add-ons: all apps or specific app, detailed metadata',
+    'List add-ons: all accessible or filtered by app',
     listAddonsOptionsSchema.shape,
     async (options: ListAddonsOptions): Promise<McpToolResponse> => {
-      const command = new CommandBuilder(TOOL_COMMAND_MAP.LIST_ADDONS)
-        .addFlags({
-          all: options.all,
-          app: options.app
-        })
-        .build();
-
-      const output = await herokuRepl.executeCommand(command);
-      return handleCliOutput(output);
+      try {
+        const result = options.app ? await sdk.listByApp(options.app) : await sdk.list();
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+        };
+      } catch (error: unknown) {
+        return formatToolError(error);
+      }
     }
   );
 };
 
-/**
- * Schema for getting information about a specific Heroku add-on.
- */
 export const getAddonInfoOptionsSchema = z.object({
   addon: z.string().describe('Add-on identifier: UUID, name (postgresql-curved-12345), or attachment name (DATABASE)'),
-  app: z
-    .string()
-    .optional()
-    .describe('App context for add-on lookup. Required for attachment names. Uses Git remote default')
+  app: z.string().optional().describe('App context for add-on lookup. Required for attachment names')
 });
 
-/**
- * Type definition for the options used when getting add-on information.
- */
 export type GetAddonInfoOptions = z.infer<typeof getAddonInfoOptionsSchema>;
 
-/**
- * Registers the get_addon_info tool with the MCP server.
- *
- * @param server - The MCP server instance to register the tool with
- * @param herokuRepl - The Heroku REPL instance for executing commands
- */
-export const registerGetAddonInfoTool = (server: McpServer, herokuRepl: HerokuREPL): void => {
+export const registerGetAddonInfoTool = (server: McpServer, sdk: AddonSdk): void => {
   server.tool(
     'get_addon_info',
-    'Get add-on details: plan, state, billing',
+    'Get add-on details: plan, state, billing, attachments',
     getAddonInfoOptionsSchema.shape,
     async (options: GetAddonInfoOptions): Promise<McpToolResponse> => {
-      const command = new CommandBuilder(TOOL_COMMAND_MAP.GET_ADDON_INFO)
-        .addFlags({ app: options.app })
-        .addPositionalArguments({ addon: options.addon })
-        .build();
-
-      const output = await herokuRepl.executeCommand(command);
-      return handleCliOutput(output);
+      try {
+        const result = await sdk.describe(options.addon, { appIdentity: options.app });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+        };
+      } catch (error: unknown) {
+        return formatToolError(error);
+      }
     }
   );
 };
 
-/**
- * Schema for creating a new Heroku add-on.
- */
 export const createAddonOptionsSchema = z.object({
-  app: z.string().describe('Target app for add-on. Must have write access. Region/space affects availability'),
+  app: z.string().describe('Target app for add-on. Must have write access'),
+  plan: z.string().describe('Service and plan (e.g., heroku-postgresql:essential-0)'),
   as: z.string().optional().describe('Custom attachment name. Used for config vars prefix. Must be unique in app'),
-  name: z.string().optional().describe('Global add-on identifier. Must be unique across all Heroku add-ons'),
-  serviceAndPlan: z.string().describe('Format: service_slug:plan_slug (e.g., heroku-postgresql:essential-0)')
+  name: z.string().optional().describe('Global add-on identifier. Must be unique across all Heroku add-ons')
 });
 
-/**
- * Type definition for the options used when creating an add-on.
- */
 export type CreateAddonOptions = z.infer<typeof createAddonOptionsSchema>;
 
-/**
- * Registers the create_addon tool with the MCP server.
- *
- * @param server - The MCP server instance to register the tool with
- * @param herokuRepl - The Heroku REPL instance for executing commands
- */
-export const registerCreateAddonTool = (server: McpServer, herokuRepl: HerokuREPL): void => {
+export const registerCreateAddonTool = (server: McpServer, sdk: AddonSdk): void => {
   server.tool(
     'create_addon',
     'Create add-on: specify service, plan, custom names',
     createAddonOptionsSchema.shape,
     async (options: CreateAddonOptions): Promise<McpToolResponse> => {
-      const command = new CommandBuilder(TOOL_COMMAND_MAP.CREATE_ADDON)
-        .addFlags({
-          app: options.app,
-          as: options.as,
-          name: options.name
-        })
-        .addPositionalArguments({ 'service:plan': options.serviceAndPlan })
-        .build();
+      try {
+        const body: { plan: string; attachment?: { name?: string }; name?: string } = {
+          plan: options.plan
+        };
+        if (options.as !== undefined) body.attachment = { name: options.as };
+        if (options.name !== undefined) body.name = options.name;
 
-      const output = await herokuRepl.executeCommand(command);
-      return handleCliOutput(output);
+        const result = await sdk.create(options.app, body);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+        };
+      } catch (error: unknown) {
+        return formatToolError(error);
+      }
     }
   );
 };
 
-/**
- * Schema for listing available add-on services.
- */
-export const listAddonServicesOptionsSchema = z.object({
-  json: z
-    .boolean()
-    .optional()
-    .describe('JSON output with sharing options and app generation support. Default: basic text')
-});
+export const listAddonServicesOptionsSchema = z.object({});
 
-/**
- * Type definition for the options used when listing add-on services.
- */
 export type ListAddonServicesOptions = z.infer<typeof listAddonServicesOptionsSchema>;
 
-/**
- * Registers the list_addon_services tool with the MCP server.
- *
- * @param server - The MCP server instance to register the tool with
- * @param herokuRepl - The Heroku REPL instance for executing commands
- */
-export const registerListAddonServicesTool = (server: McpServer, herokuRepl: HerokuREPL): void => {
+export const registerListAddonServicesTool = (server: McpServer, sdk: AddonSdk): void => {
   server.tool(
     'list_addon_services',
     'List available add-on services and features',
     listAddonServicesOptionsSchema.shape,
-    async (options: ListAddonServicesOptions): Promise<McpToolResponse> => {
-      const command = new CommandBuilder(TOOL_COMMAND_MAP.LIST_ADDON_SERVICES)
-        .addFlags({
-          json: options.json
-        })
-        .build();
-
-      const output = await herokuRepl.executeCommand(command);
-      return handleCliOutput(output);
+    async (): Promise<McpToolResponse> => {
+      try {
+        const result = await sdk.listServices();
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+        };
+      } catch (error: unknown) {
+        return formatToolError(error);
+      }
     }
   );
 };
 
-/**
- * Schema for listing plans for a specific add-on service.
- */
 export const listAddonPlansOptionsSchema = z.object({
-  service: z.string().describe('Service slug (e.g., heroku-postgresql). Get from list_addon_services'),
-  json: z.boolean().optional().describe('JSON output with pricing, features, space compatibility. Default: text format')
+  service: z.string().describe('Service slug (e.g., heroku-postgresql). Get from list_addon_services')
 });
 
-/**
- * Type definition for the options used when listing add-on service plans.
- */
 export type ListAddonPlansOptions = z.infer<typeof listAddonPlansOptionsSchema>;
 
-/**
- * Registers the list_addon_plans tool with the MCP server.
- *
- * @param server - The MCP server instance to register the tool with
- * @param herokuRepl - The Heroku REPL instance for executing commands
- */
-export const registerListAddonPlansTool = (server: McpServer, herokuRepl: HerokuREPL): void => {
+export const registerListAddonPlansTool = (server: McpServer, sdk: AddonSdk): void => {
   server.tool(
     'list_addon_plans',
     'List service plans: features, pricing, availability',
     listAddonPlansOptionsSchema.shape,
     async (options: ListAddonPlansOptions): Promise<McpToolResponse> => {
-      const command = new CommandBuilder(TOOL_COMMAND_MAP.LIST_ADDON_PLANS)
-        .addFlags({
-          json: options.json
-        })
-        .addPositionalArguments({ service: options.service })
-        .build();
-
-      const output = await herokuRepl.executeCommand(command);
-      return handleCliOutput(output);
+      try {
+        const result = await sdk.listPlans(options.service);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+        };
+      } catch (error: unknown) {
+        return formatToolError(error);
+      }
     }
   );
 };

--- a/src/utils/command-builder.spec.ts
+++ b/src/utils/command-builder.spec.ts
@@ -1,53 +1,47 @@
 import { expect } from 'chai';
 import { CommandBuilder } from './command-builder.js';
-import { TOOL_COMMAND_MAP } from './tool-commands.js';
-
-/**
- * Unit tests for the CommandBuilder class.
- * Some of these tests do not produce valid commands, but they are designed to test the CommandBuilder class.
- */
 
 describe('CommandBuilder', () => {
   describe('constructor', () => {
     it('creates a new instance with the base command', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      const builder = new CommandBuilder('apps');
       expect(builder.build()).to.equal('apps');
     });
   });
 
   describe('addFlags', () => {
     it('adds boolean flags correctly', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      const builder = new CommandBuilder('apps');
       builder.addFlags({ all: true, json: true });
       expect(builder.build()).to.equal('apps --all --json');
     });
 
     it('adds string flags with values correctly', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      const builder = new CommandBuilder('apps');
       builder.addFlags({ team: 'my-team', space: 'my-space' });
       expect(builder.build()).to.equal('apps --team=my-team --space=my-space');
     });
 
     it('handles mixed boolean and string flags', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      const builder = new CommandBuilder('apps');
       builder.addFlags({ all: true, team: 'my-team', json: true });
       expect(builder.build()).to.equal('apps --all --team=my-team --json');
     });
 
     it('ignores undefined flag values', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      const builder = new CommandBuilder('apps');
       builder.addFlags({ all: true, team: undefined, json: true });
       expect(builder.build()).to.equal('apps --all --json');
     });
 
     it('ignores false boolean flags', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      const builder = new CommandBuilder('apps');
       builder.addFlags({ all: false, json: true });
       expect(builder.build()).to.equal('apps --json');
     });
 
     it('supports method chaining', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      const builder = new CommandBuilder('apps');
       const result = builder.addFlags({ all: true });
       expect(result).to.equal(builder);
     });
@@ -55,25 +49,25 @@ describe('CommandBuilder', () => {
 
   describe('addPositionalArguments', () => {
     it('adds positional arguments correctly', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
+      const builder = new CommandBuilder('apps:rename');
       builder.addPositionalArguments({ new_name: 'new-app-name' });
       expect(builder.build()).to.equal('apps:rename -- new-app-name');
     });
 
     it('adds multiple positional arguments in order', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.TRANSFER_APP);
+      const builder = new CommandBuilder('apps:transfer');
       builder.addPositionalArguments({ app: 'my-app', recipient: 'user@example.com' });
       expect(builder.build()).to.equal('apps:transfer -- my-app user@example.com');
     });
 
     it('ignores undefined argument values', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
+      const builder = new CommandBuilder('apps:rename');
       builder.addPositionalArguments({ app: undefined, new_name: 'new-app-name' });
       expect(builder.build()).to.equal('apps:rename -- new-app-name');
     });
 
     it('supports method chaining', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
+      const builder = new CommandBuilder('apps:rename');
       const result = builder.addPositionalArguments({ new_name: 'new-app-name' });
       expect(result).to.equal(builder);
     });
@@ -81,30 +75,30 @@ describe('CommandBuilder', () => {
 
   describe('build', () => {
     it('combines flags and positional arguments correctly', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.CREATE_APP);
+      const builder = new CommandBuilder('apps:create');
       builder.addFlags({ region: 'eu', team: 'my-team' }).addPositionalArguments({ app: 'my-new-app' });
       expect(builder.build()).to.equal('apps:create --region=eu --team=my-team -- my-new-app');
     });
 
     it('handles commands with no flags or arguments', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      const builder = new CommandBuilder('apps');
       expect(builder.build()).to.equal('apps');
     });
 
     it('handles commands with only flags', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      const builder = new CommandBuilder('apps');
       builder.addFlags({ all: true, json: true });
       expect(builder.build()).to.equal('apps --all --json');
     });
 
     it('handles commands with only positional arguments', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
+      const builder = new CommandBuilder('apps:rename');
       builder.addPositionalArguments({ new_name: 'new-app-name' });
       expect(builder.build()).to.equal('apps:rename -- new-app-name');
     });
 
     it('maintains flag and argument order across multiple calls', () => {
-      const builder = new CommandBuilder(TOOL_COMMAND_MAP.CREATE_APP);
+      const builder = new CommandBuilder('apps:create');
       builder.addFlags({ region: 'eu' }).addPositionalArguments({ app: 'my-app' }).addFlags({ team: 'my-team' });
       expect(builder.build()).to.equal('apps:create --region=eu --team=my-team -- my-app');
     });

--- a/src/utils/tool-commands.ts
+++ b/src/utils/tool-commands.ts
@@ -3,25 +3,11 @@
  * This mapping ensures consistent command usage across the application.
  */
 export const TOOL_COMMAND_MAP = {
-  // App-related commands
-  LIST_APPS: 'apps',
-  CREATE_APP: 'apps:create',
-  RENAME_APP: 'apps:rename',
-  TRANSFER_APP: 'apps:transfer',
-  GET_APP_INFO: 'apps:info',
-
   // Space-related commands
   LIST_PRIVATE_SPACES: 'spaces',
 
   // Team-related commands
   LIST_TEAMS: 'teams',
-
-  // Addons commands
-  LIST_ADDONS: 'addons',
-  GET_ADDON_INFO: 'addons:info',
-  CREATE_ADDON: 'addons:create',
-  LIST_ADDON_SERVICES: 'addons:services',
-  LIST_ADDON_PLANS: 'addons:plans',
 
   // PostgreSQL commands
   PG_PSQL: 'pg:psql',


### PR DESCRIPTION
## Summary

Refactors add-on tooling to use the Heroku SDK directly instead of CLI command construction, aligning add-on operations with the same injected-SDK pattern used in other migrated tools. The change also updates wiring and tests so add-on tools return consistent SDK-backed JSON/error responses.

- **Refactor** add-on tool handlers to call injected `AddonSdk` methods instead of `HerokuREPL` commands
- **Add** add-on SDK wiring in `src/index.ts` and enable `addOnExtensions` in shared `HerokuSDK` initialization
- **Replace** command-builder/output parsing flow in add-on tools with direct SDK result serialization
- **Update** add-on schemas and payload mapping (including `create_addon` using `plan` request body construction)
- **Update** add-on unit tests to stub SDK methods and assert success/error behavior
- **Remove** obsolete add-on command constants from `TOOL_COMMAND_MAP`
- **Clean up** `command-builder` tests to avoid dependency on removed command-map entries

## Type of Change

- [ ] **fix**: Bug fix or issue (patch semvar update)
- [x] **feat**: Introduces a new feature to the codebase (minor semvar update)
- [ ] **perf**: Performance improvement
- [ ] **docs**: Documentation only changes
- [ ] **tests**: Adding missing tests or correcting existing tests
- [ ] **chore**: Code cleanup tasks, dependency updates, or other changes

## Verification

```bash
npm ci
npm run build
npm test
npx -y @modelcontextprotocol/inspector@latest node bin/heroku-mcp-server.mjs
```

In MCP Inspector:
- Connect and list tools
- Exercise `list_addons`, `get_addon_info`, `create_addon`, `list_addon_services`, and `list_addon_plans`
- Validate success responses return serialized JSON and failures return standardized MCP error format

## Additional Context

- **Breaking:** potential request-shape changes for add-on callers (notably `create_addon` input naming/semantics and removed CLI-specific flags)
- **Risk:** medium; API contract changes for existing MCP clients may require prompt/tool-call updates
- **Follow-up:** consider compatibility aliases or explicit migration notes for callers using prior add-on parameters

## Related Issue

[W-22265162](https://gus.lightning.force.com/a07EE00002Z0BdGYAV)