### PR TITLE
Handle metadata flags before server startup

### DIFF
--- a/bin/heroku-mcp-server.mjs
+++ b/bin/heroku-mcp-server.mjs
@@ -1,5 +1,31 @@
 #!/usr/bin/env node
 /* global process */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+const flag = process.argv[2];
+
+if (flag === '--version' || flag === '-v') {
+  process.stdout.write(`${packageJson.version}\n`);
+  process.exit(0);
+}
+
+if (flag === '--help' || flag === '-h') {
+  process.stdout.write(`heroku-mcp-server ${packageJson.version}
+
+Usage:
+  heroku-mcp-server [options]
+
+Options:
+  -h, --help      Show this help message
+  -v, --version   Show version number
+`);
+  process.exit(0);
+}
+
 try {
   const { runServer } = await import('../dist/index.js');
   await runServer();

--- a/src/cli-metadata.spec.ts
+++ b/src/cli-metadata.spec.ts
@@ -1,0 +1,37 @@
+/* eslint-disable prefer-arrow-callback */
+import { expect } from 'chai';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as pjson from '../package.json' with { type: 'json' };
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const VERSION = pjson.default.version;
+
+function runCli(flag: string) {
+  return spawnSync(process.execPath, ['bin/heroku-mcp-server.mjs', flag], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    timeout: 3000
+  });
+}
+
+describe('CLI metadata flags', function () {
+  it('prints the package version without starting the server', function () {
+    const result = runCli('--version');
+
+    expect(result.status, result.stderr).to.equal(0);
+    expect(result.stdout.trim()).to.equal(VERSION);
+    expect(result.stderr).to.equal('');
+  });
+
+  it('prints help without starting the server', function () {
+    const result = runCli('--help');
+
+    expect(result.status, result.stderr).to.equal(0);
+    expect(result.stdout).to.include('heroku-mcp-server');
+    expect(result.stdout).to.include('--version');
+    expect(result.stderr).to.equal('');
+  });
+});


### PR DESCRIPTION
## Summary
- handle `--help`, `-h`, `--version`, and `-v` in the package bin before importing the MCP server
- print package metadata without starting the stdio server or plugin checks
- add regression coverage for the metadata flags

## Why
Running `heroku-mcp-server --version` or `heroku-mcp-server --help` currently starts the server path instead of returning metadata, which makes common CLI introspection hang on stdio.

## Validation
- `npm test -- --grep "CLI metadata flags"`
- `cd src && npx eslint cli-metadata.spec.ts`
- `npm run build`
- `npm run type-check`
- `npm pack --pack-destination /tmp/automoney-heroku-pack`
- `npm exec --yes --package=/tmp/automoney-heroku-pack/heroku-mcp-server-1.2.2.tgz -- heroku-mcp-server --version`
- `npm exec --yes --package=/tmp/automoney-heroku-pack/heroku-mcp-server-1.2.2.tgz -- heroku-mcp-server --help`
- no-arg tarball smoke still starts the stdio server and timed out after printing `Heroku MCP Server running on stdio`