### PR TITLE
fix: reject CR/LF in CLI flag values and positional arguments

### DIFF
--- a/src/utils/command-builder.spec.ts
+++ b/src/utils/command-builder.spec.ts
@@ -51,6 +51,19 @@ describe('CommandBuilder', () => {
       const result = builder.addFlags({ all: true });
       expect(result).to.equal(builder);
     });
+
+    it('rejects flag values containing line breaks to prevent REPL command injection', () => {
+      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      expect(() => builder.addFlags({ team: 'my-team\napps:destroy --confirm victim' })).to.throw(
+        /line breaks \(CR\/LF\) are not allowed/
+      );
+      expect(() => builder.addFlags({ team: 'my-team\rother' })).to.throw(/line breaks/);
+    });
+
+    it('still allows flag values that contain spaces (only line breaks are rejected)', () => {
+      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      expect(() => builder.addFlags({ team: 'my team' })).to.not.throw();
+    });
   });
 
   describe('addPositionalArguments', () => {
@@ -76,6 +89,13 @@ describe('CommandBuilder', () => {
       const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
       const result = builder.addPositionalArguments({ new_name: 'new-app-name' });
       expect(result).to.equal(builder);
+    });
+
+    it('rejects positional argument values containing line breaks', () => {
+      const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
+      expect(() => builder.addPositionalArguments({ new_name: 'ok\napps:destroy --confirm victim' })).to.throw(
+        /line breaks \(CR\/LF\) are not allowed/
+      );
     });
   });
 

--- a/src/utils/command-builder.ts
+++ b/src/utils/command-builder.ts
@@ -1,4 +1,16 @@
 /**
+ * Characters that must never appear in a flag value or positional argument.
+ *
+ * Each built command is delivered to the Heroku CLI as a single line — the REPL
+ * writes `command + '\n'` to the CLI process's stdin (see `HerokuREPL`). A carriage
+ * return or line feed embedded in a value would therefore terminate the current
+ * command and begin another, allowing an untrusted value to inject an additional,
+ * unintended CLI command into the stream. There is no legitimate reason for a flag
+ * value or positional argument to contain a line break, so they are rejected.
+ */
+const LINE_BREAK_PATTERN = /[\r\n]/;
+
+/**
  * A builder class for constructing Heroku CLI commands with flags and positional arguments.
  * This class provides a fluent interface for building command-line arguments in a structured way.
  */
@@ -17,6 +29,22 @@ export class CommandBuilder {
   }
 
   /**
+   * Rejects values that would break out of the single command line they belong to.
+   *
+   * @param kind - Whether the value is a flag value or a positional argument (for the error message).
+   * @param name - The flag/argument name the value is associated with (for the error message).
+   * @param value - The value to validate.
+   * @throws {Error} If the value contains a carriage return or line feed.
+   */
+  private static assertNoLineBreaks(kind: 'argument' | 'flag', name: string, value: string): void {
+    if (LINE_BREAK_PATTERN.test(value)) {
+      throw new Error(
+        `Invalid ${kind} value for "${name}": line breaks (CR/LF) are not allowed. Commands are sent one per line to the Heroku CLI, so an embedded newline would be interpreted as the start of a separate command.`
+      );
+    }
+  }
+
+  /**
    * Adds command-line flags to the command.
    *
    * @param flags - An object containing flag names and their values. Boolean flags are added without values,
@@ -27,7 +55,10 @@ export class CommandBuilder {
     for (const [flag, value] of Object.entries(flags)) {
       if (value) {
         if (typeof value === 'boolean') this.flags.push(`--${flag}`);
-        else this.flags.push(`--${flag}=${value}`);
+        else {
+          CommandBuilder.assertNoLineBreaks('flag', flag, value);
+          this.flags.push(`--${flag}=${value}`);
+        }
       }
     }
     return this;
@@ -40,8 +71,11 @@ export class CommandBuilder {
    * @returns The builder instance for method chaining
    */
   public addPositionalArguments(args: Record<string, string | undefined>): this {
-    for (const [, value] of Object.entries(args)) {
-      if (value) this.args.push(value);
+    for (const [name, value] of Object.entries(args)) {
+      if (value) {
+        CommandBuilder.assertNoLineBreaks('argument', name, value);
+        this.args.push(value);
+      }
     }
     return this;
   }


### PR DESCRIPTION
## Summary

`CommandBuilder` assembles each Heroku CLI command as a single string and the REPL delivers it to the CLI process one line at a time — `HerokuREPL` writes `command + '\n'` to stdin (`src/repl/heroku-cli-repl.ts`). Today `addFlags` emits `--flag=${value}` and `addPositionalArguments` pushes raw values, with **no validation of the value contents**.

Because the command is newline-delimited on the wire, a flag value or positional argument that contains a **carriage return or line feed** terminates the intended command and begins another one. Any value that originates from untrusted input — e.g. a tool argument chosen by the model, which in an agentic setting can be steered by prompt injection or a poisoned tool result — can therefore append an **additional, unintended CLI command** to the REPL stream (run under the operator's authenticated Heroku session).

This PR rejects CR/LF in flag values and positional arguments at the single point where the command line is assembled (`CommandBuilder`). It generalizes the protection the `pg:psql` tool already applies to its one free-form field (`src/tools/data.ts`, which strips newlines before building the command) so every flag value and argument is covered centrally.

- Values containing **spaces are unaffected** — only line breaks (CR/LF) are rejected, so legitimate values (config var values, multi-word inputs) keep working.
- Fail-closed: an invalid value throws a clear `Error` rather than being silently altered, so callers surface the bad input instead of issuing a surprising command.

## Type of Change

### Patch Updates (patch semver update)

- [x] **fix**: Bug fix

## Testing

`npm test` — 195 passing (3 new). New `CommandBuilder` unit tests cover:
- flag values containing `\n` / `\r` are rejected,
- positional argument values containing `\n` are rejected,
- values containing spaces still pass (scope is line breaks only).

No behavior change for any existing test or any value that doesn't contain a line break.