### PR TITLE
fix: invoke heroku CLI repl as subcommand instead of --repl flag

### DIFF
--- a/src/repl/heroku-cli-repl.spec.ts
+++ b/src/repl/heroku-cli-repl.spec.ts
@@ -204,7 +204,7 @@ describe('HerokuREPL', () => {
 
       expect(result).to.deep.equal({
         cliCommand: 'npx',
-        cliArgs: ['-y', 'heroku@latest', '--repl']
+        cliArgs: ['-y', 'heroku@latest', 'repl']
       });
       expect(fatalSpy.called).to.be.false;
     });
@@ -228,7 +228,7 @@ describe('HerokuREPL', () => {
 
       expect(result).to.deep.equal({
         cliCommand: 'heroku',
-        cliArgs: ['--repl']
+        cliArgs: ['repl']
       });
       expect(fatalSpy.called).to.be.false;
     });
@@ -252,7 +252,7 @@ describe('HerokuREPL', () => {
 
       expect(result).to.deep.equal({
         cliCommand: 'heroku',
-        cliArgs: ['--repl']
+        cliArgs: ['repl']
       });
       expect(fatalSpy.called).to.be.false;
     });

--- a/src/repl/heroku-cli-repl.ts
+++ b/src/repl/heroku-cli-repl.ts
@@ -123,7 +123,7 @@ export class HerokuREPL extends EventEmitter {
       shell: process.platform === 'win32'
     });
     if (!npxCheck.error && npxCheck.status === 0) {
-      return { cliCommand: 'npx', cliArgs: ['-y', 'heroku@latest', '--repl'] };
+      return { cliCommand: 'npx', cliArgs: ['-y', 'heroku@latest', 'repl'] };
     } else {
       // Fallback: check for heroku CLI and version
       const herokuCheck = HerokuREPL.spawnSync('heroku', ['version'], {
@@ -140,7 +140,7 @@ export class HerokuREPL extends EventEmitter {
         if (versionMatch) {
           const [major, minor] = versionMatch[1].split('.').map(Number);
           if (major > 10 || (major === 10 && minor >= 10)) {
-            return { cliCommand: 'heroku', cliArgs: ['--repl'] };
+            return { cliCommand: 'heroku', cliArgs: ['repl'] };
           } else {
             this.emit(
               'fatalError',


### PR DESCRIPTION
## Summary

The MCP server spawns the Heroku CLI in REPL mode to durably execute commands. It was invoking the REPL with the `--repl` **flag**, but the Heroku CLI has since moved the REPL to a `repl` **subcommand**. The published CLI rejects `--repl` with `Warning: --repl is not a heroku command.` written to **stderr** — but the server's "not a command" guard only inspects **stdout**. The rejection was silently swallowed: the REPL process exited, the `heroku >` ready prompt never arrived, `isReady` stayed `false`, and every tool call hung forever waiting for the `<<<END RESULTS>>>` sentinel.

This made every tool (e.g. `list_apps`) hang with no error surfaced to the MCP client.

Fix: invoke the `repl` subcommand in both spawn paths (`npx -y heroku@latest repl` and the PATH `heroku repl` fallback), and update the affected specs.

## Type of Change

### Patch Updates (patch semver update)

- [x] **fix**: Bug fix

## Testing

### Prerequisites

- Node.js >= 20 (provides `npx`).
- Logged in to the Heroku CLI (`heroku login`) so `list_apps` has an account to query. _(Any logged-in account works — the point is that the REPL becomes ready and replies instead of hanging.)_

### What this exercises

The server prefers `npx -y heroku@latest repl` whenever `npx` is available, so these steps test the published-CLI path with no special setup. The published `heroku@latest` already exposes `repl` as a subcommand.

### 1. Build

```bash
npm run build
```

### 2. Drive the built server over stdio and confirm `list_apps` responds

Paste this whole block. It sends the three required JSON-RPC messages — `initialize`, the `notifications/initialized` handshake, then `tools/call list_apps` — as newline-delimited JSON, and holds stdin open while the REPL spawns the CLI:

```bash
{
  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"review","version":"0"}}}'
  printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
  printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_apps","arguments":{}}}'
  sleep 25
} | node bin/heroku-mcp-server.mjs 2>/dev/null
```

**Expected (fix applied):** two JSON lines — the `initialize` result (`"id":1`), then within a few seconds a `list_apps` result (`"id":2`) whose `content` text contains your app list wrapped in `<<<BEGIN RESULTS>>> … <<<END RESULTS>>>`:

```
{"result":{"protocolVersion":"2025-06-18",...},"jsonrpc":"2.0","id":1}
{"result":{"content":[{"type":"text","text":"<<<BEGIN RESULTS>>>\n...apps...\n<<<END RESULTS>>>"}]},"jsonrpc":"2.0","id":2}
```

> The `sleep 25` covers a cold `npx` fetch of `heroku@latest`; a warm run responds in ~2–3s. Increase it if your network is slow.

### 3. (Optional) Observe the bug before the fix

On `main`, the same command from step 2 prints **only** the `"id":1` line and never the `"id":2` result — the call hangs until the `sleep` ends, which is the symptom this PR fixes.

You can also see the underlying cause directly — the published CLI rejecting the old flag on **stderr** (which the server's stdout-only guard missed):

```bash
echo | npx -y heroku@latest --repl
#  ›   Warning: --repl is not a heroku command.
```

### 4. Unit tests

```bash
npm test
```

All tests pass (the three updated specs assert `repl` instead of `--repl`).

## Related Issues

GUS work item: [W-23095439](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cequpYAA/view)
