### PR TITLE
bug: reject CR/LF in CLI flag values and positional arguments

### DIFF
--- a/src/repl/heroku-cli-repl.spec.ts
+++ b/src/repl/heroku-cli-repl.spec.ts
@@ -104,6 +104,44 @@ describe('HerokuREPL', () => {
     });
   });
 
+  describe('stdin command injection (threat model)', () => {
+    // This test locks in the exact bytes written to the CLI process stdin.
+    // Commands are newline-delimited on stdin, so the REPL appends a single
+    // trailing '\n' to signal "end of command". This is precisely why an
+    // embedded '\n' inside a command string is dangerous: the CLI would treat
+    // everything after the embedded newline as a SECOND command. The
+    // CommandBuilder CR/LF guard upstream is what defends against that; this
+    // test documents the exact-bytes behavior it relies on.
+
+    it('should write exactly command + a single trailing newline to stdin', async () => {
+      const command = 'apps';
+
+      // Deterministically resolve the moment the async iterator writes to
+      // stdin, rather than waiting a fixed duration.
+      let onWrite!: () => void;
+      const written = new Promise<void>((resolve) => {
+        onWrite = resolve;
+      });
+      mockProcess.stdin.write.callsFake(() => {
+        onWrite();
+        return true;
+      });
+
+      const commandPromise = repl.executeCommand(command);
+
+      // Proceed as soon as the write actually happens.
+      await written;
+
+      expect(mockProcess.stdin.write.calledOnce).to.be.true;
+      const writtenValue = mockProcess.stdin.write.firstCall.args[0] as string;
+      expect(writtenValue).to.equal(command + '\n');
+
+      // Clean up the outstanding command promise.
+      setTimeout(() => mockProcess.stdout.emit('data', 'Command output\n<<<END RESULTS>>>'));
+      await commandPromise;
+    });
+  });
+
   describe('process management', () => {
     it('should restart process on unexpected close', () => {
       mockProcess.emit('close', 1);

--- a/src/repl/heroku-cli-repl.spec.ts
+++ b/src/repl/heroku-cli-repl.spec.ts
@@ -104,14 +104,14 @@ describe('HerokuREPL', () => {
     });
   });
 
-  describe('stdin command injection (threat model)', () => {
+  describe('stdin protocol', () => {
     // This test locks in the exact bytes written to the CLI process stdin.
     // Commands are newline-delimited on stdin, so the REPL appends a single
-    // trailing '\n' to signal "end of command". This is precisely why an
-    // embedded '\n' inside a command string is dangerous: the CLI would treat
-    // everything after the embedded newline as a SECOND command. The
-    // CommandBuilder CR/LF guard upstream is what defends against that; this
-    // test documents the exact-bytes behavior it relies on.
+    // trailing '\n' to signal "end of command". This is why a command string
+    // must itself be a single line: the CLI treats everything after an embedded
+    // newline as a separate command. The CommandBuilder CR/LF validation
+    // upstream enforces that; this test documents the exact-bytes behavior it
+    // relies on.
 
     it('should write exactly command + a single trailing newline to stdin', async () => {
       const command = 'apps';

--- a/src/tools/apps.spec.ts
+++ b/src/tools/apps.spec.ts
@@ -332,9 +332,9 @@ describe('apps topic tools', () => {
     });
   });
 
-  // Command injection prevention: malicious input routed through a real tool handler
-  // must be rejected by CommandBuilder before it can reach the Heroku REPL.
-  describe('command injection prevention', () => {
+  // Input validation: a multi-line value routed through a real tool handler must be
+  // rejected by CommandBuilder before it can reach the Heroku REPL.
+  describe('input validation', () => {
     let mocks: ReturnType<typeof setupMcpToolMocks>;
 
     beforeEach(() => {
@@ -345,50 +345,50 @@ describe('apps topic tools', () => {
       sinon.restore();
     });
 
-    it('rejects a newline-injected team flag on list_apps without executing the payload', async () => {
-      const maliciousTeam = 'my-team\napps:destroy --confirm victim';
+    it('rejects a multi-line team flag on list_apps without executing it', async () => {
+      const multiLineTeam = 'my-team\nsecond-line';
       registerListAppsTool(mocks.server, mocks.herokuRepl);
       const toolCallback = mocks.getToolCallback();
 
       let error: Error | undefined;
       try {
-        await toolCallback({ team: maliciousTeam }, {});
+        await toolCallback({ team: multiLineTeam }, {});
       } catch (caught) {
         error = caught as Error;
       }
 
-      // The injection must be surfaced as an error...
+      // The invalid value must be surfaced as an error...
       expect(error).to.be.an('Error');
 
-      // ...and the malicious payload must never reach the REPL.
+      // ...and must never reach the REPL.
       expect(mocks.herokuRepl.executeCommand.called).to.be.false;
-      const executedWithInjection = mocks.herokuRepl.executeCommand
+      const executedWithLineBreak = mocks.herokuRepl.executeCommand
         .getCalls()
         .some((call) => typeof call.args[0] === 'string' && call.args[0].includes('\n'));
-      expect(executedWithInjection).to.be.false;
+      expect(executedWithLineBreak).to.be.false;
     });
 
-    it('rejects a newline-injected newName argument on rename_app without executing the payload', async () => {
-      const maliciousNewName = 'renamed-app\napps:destroy --confirm victim';
+    it('rejects a multi-line newName argument on rename_app without executing it', async () => {
+      const multiLineNewName = 'renamed-app\nsecond-line';
       registerRenameAppTool(mocks.server, mocks.herokuRepl);
       const toolCallback = mocks.getToolCallback();
 
       let error: Error | undefined;
       try {
-        await toolCallback({ app: 'test-app', newName: maliciousNewName }, {});
+        await toolCallback({ app: 'test-app', newName: multiLineNewName }, {});
       } catch (caught) {
         error = caught as Error;
       }
 
-      // The injection must be surfaced as an error...
+      // The invalid value must be surfaced as an error...
       expect(error).to.be.an('Error');
 
-      // ...and the malicious payload must never reach the REPL.
+      // ...and must never reach the REPL.
       expect(mocks.herokuRepl.executeCommand.called).to.be.false;
-      const executedWithInjection = mocks.herokuRepl.executeCommand
+      const executedWithLineBreak = mocks.herokuRepl.executeCommand
         .getCalls()
         .some((call) => typeof call.args[0] === 'string' && call.args[0].includes('\n'));
-      expect(executedWithInjection).to.be.false;
+      expect(executedWithLineBreak).to.be.false;
     });
   });
 });

--- a/src/tools/apps.spec.ts
+++ b/src/tools/apps.spec.ts
@@ -331,4 +331,64 @@ describe('apps topic tools', () => {
       }
     });
   });
+
+  // Command injection prevention: malicious input routed through a real tool handler
+  // must be rejected by CommandBuilder before it can reach the Heroku REPL.
+  describe('command injection prevention', () => {
+    let mocks: ReturnType<typeof setupMcpToolMocks>;
+
+    beforeEach(() => {
+      mocks = setupMcpToolMocks();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('rejects a newline-injected team flag on list_apps without executing the payload', async () => {
+      const maliciousTeam = 'my-team\napps:destroy --confirm victim';
+      registerListAppsTool(mocks.server, mocks.herokuRepl);
+      const toolCallback = mocks.getToolCallback();
+
+      let error: Error | undefined;
+      try {
+        await toolCallback({ team: maliciousTeam }, {});
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      // The injection must be surfaced as an error...
+      expect(error).to.be.an('Error');
+
+      // ...and the malicious payload must never reach the REPL.
+      expect(mocks.herokuRepl.executeCommand.called).to.be.false;
+      const executedWithInjection = mocks.herokuRepl.executeCommand
+        .getCalls()
+        .some((call) => typeof call.args[0] === 'string' && call.args[0].includes('\n'));
+      expect(executedWithInjection).to.be.false;
+    });
+
+    it('rejects a newline-injected newName argument on rename_app without executing the payload', async () => {
+      const maliciousNewName = 'renamed-app\napps:destroy --confirm victim';
+      registerRenameAppTool(mocks.server, mocks.herokuRepl);
+      const toolCallback = mocks.getToolCallback();
+
+      let error: Error | undefined;
+      try {
+        await toolCallback({ app: 'test-app', newName: maliciousNewName }, {});
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      // The injection must be surfaced as an error...
+      expect(error).to.be.an('Error');
+
+      // ...and the malicious payload must never reach the REPL.
+      expect(mocks.herokuRepl.executeCommand.called).to.be.false;
+      const executedWithInjection = mocks.herokuRepl.executeCommand
+        .getCalls()
+        .some((call) => typeof call.args[0] === 'string' && call.args[0].includes('\n'));
+      expect(executedWithInjection).to.be.false;
+    });
+  });
 });

--- a/src/tools/data.spec.ts
+++ b/src/tools/data.spec.ts
@@ -83,15 +83,15 @@ describe('PostgreSQL Tools', () => {
     //
     // These tests document the CURRENT (and intentionally inconsistent) behavior
     // of pg:psql. Unlike every other tool -- which relies on CommandBuilder's
-    // CR/LF guard to REJECT any value containing a line break -- pg:psql
+    // CR/LF validation to REJECT any value containing a line break -- pg:psql
     // pre-processes its `command` value with `replaceAll('\n', ' ')` in data.ts
     // BEFORE it reaches CommandBuilder (see the `command:` flag in
     // registerPgPsqlTool). As a result:
     //   * a line feed (\n) is SILENTLY REWRITTEN to a space (strip, not reject),
     //   * but a carriage return (\r) is NOT touched by that replace and still
-    //     reaches CommandBuilder's guard.
+    //     reaches CommandBuilder's validation.
     //
-    // If pg:psql is ever unified with the reject-everywhere approach (i.e. the
+    // If pg:psql is ever unified with the reject-everywhere validation (i.e. the
     // `replaceAll('\n', ' ')` is removed so LF is rejected like everywhere else),
     // these tests will intentionally break -- signalling that the documented
     // behavior changed on purpose.
@@ -115,10 +115,10 @@ describe('PostgreSQL Tools', () => {
 
     // OBSERVED BEHAVIOR (verified by running this spec): a carriage return (\r) in
     // `command` is NOT stripped by `replaceAll('\n', ' ')`, so it reaches
-    // CommandBuilder's CR/LF guard and is REJECTED -- the tool callback REJECTS
+    // CommandBuilder's CR/LF validation and is REJECTED -- the tool callback REJECTS
     // (throws) and executeCommand is never called. This differs from the LF case
     // above, which is silently stripped.
-    it('CHARACTERIZATION: rejects a CR in command (not stripped) via the CommandBuilder guard', async () => {
+    it('CHARACTERIZATION: rejects a CR in command (not stripped) via CommandBuilder validation', async () => {
       mocks.herokuRepl.executeCommand.resolves('Query executed successfully\n');
 
       let thrownError: Error | undefined;
@@ -128,7 +128,7 @@ describe('PostgreSQL Tools', () => {
         thrownError = error as Error;
       }
 
-      // The \r is not touched by replaceAll('\n', ' '), so CommandBuilder throws.
+      // The \r is not touched by replaceAll('\n', ' '), so CommandBuilder rejects it.
       expect(thrownError, 'expected the tool callback to throw for a CR in command').to.be.an('error');
       expect(thrownError?.message).to.include('line breaks (CR/LF) are not allowed');
       // Because building the command threw, the command was never executed.

--- a/src/tools/data.spec.ts
+++ b/src/tools/data.spec.ts
@@ -77,6 +77,63 @@ describe('PostgreSQL Tools', () => {
         isError: true
       });
     });
+
+    // ---------------------------------------------------------------------------
+    // CHARACTERIZATION TESTS: newline handling in the `command` value.
+    //
+    // These tests document the CURRENT (and intentionally inconsistent) behavior
+    // of pg:psql. Unlike every other tool -- which relies on CommandBuilder's
+    // CR/LF guard to REJECT any value containing a line break -- pg:psql
+    // pre-processes its `command` value with `replaceAll('\n', ' ')` in data.ts
+    // BEFORE it reaches CommandBuilder (see the `command:` flag in
+    // registerPgPsqlTool). As a result:
+    //   * a line feed (\n) is SILENTLY REWRITTEN to a space (strip, not reject),
+    //   * but a carriage return (\r) is NOT touched by that replace and still
+    //     reaches CommandBuilder's guard.
+    //
+    // If pg:psql is ever unified with the reject-everywhere approach (i.e. the
+    // `replaceAll('\n', ' ')` is removed so LF is rejected like everywhere else),
+    // these tests will intentionally break -- signalling that the documented
+    // behavior changed on purpose.
+    // ---------------------------------------------------------------------------
+
+    it('CHARACTERIZATION: strips (does not reject) a LF in command, replacing it with a space', async () => {
+      mocks.herokuRepl.executeCommand.resolves('Query executed successfully\n');
+
+      // Multi-line SQL: the LF between the two statements should be converted to a space.
+      await toolCallback({ app: 'myapp', command: 'SELECT 1;\nSELECT 2;' });
+
+      expect(mocks.herokuRepl.executeCommand.calledOnce).to.be.true;
+      const builtCommand = mocks.herokuRepl.executeCommand.firstCall.args[0] as string;
+
+      // The newline was replaced by a space BEFORE reaching CommandBuilder, so the
+      // command is NOT rejected and the built command contains the space-joined SQL.
+      expect(builtCommand).to.equal(`${TOOL_COMMAND_MAP.PG_PSQL} --app=myapp --command="SELECT 1; SELECT 2;"`);
+      // Confirm no raw LF survived in the command sent to the CLI.
+      expect(builtCommand).to.not.include('\n');
+    });
+
+    // OBSERVED BEHAVIOR (verified by running this spec): a carriage return (\r) in
+    // `command` is NOT stripped by `replaceAll('\n', ' ')`, so it reaches
+    // CommandBuilder's CR/LF guard and is REJECTED -- the tool callback REJECTS
+    // (throws) and executeCommand is never called. This differs from the LF case
+    // above, which is silently stripped.
+    it('CHARACTERIZATION: rejects a CR in command (not stripped) via the CommandBuilder guard', async () => {
+      mocks.herokuRepl.executeCommand.resolves('Query executed successfully\n');
+
+      let thrownError: Error | undefined;
+      try {
+        await toolCallback({ app: 'myapp', command: 'SELECT 1;\rSELECT 2;' });
+      } catch (error) {
+        thrownError = error as Error;
+      }
+
+      // The \r is not touched by replaceAll('\n', ' '), so CommandBuilder throws.
+      expect(thrownError, 'expected the tool callback to throw for a CR in command').to.be.an('error');
+      expect(thrownError?.message).to.include('line breaks (CR/LF) are not allowed');
+      // Because building the command threw, the command was never executed.
+      expect(mocks.herokuRepl.executeCommand.called).to.be.false;
+    });
   });
 
   describe('pg:info', () => {

--- a/src/utils/command-builder.spec.ts
+++ b/src/utils/command-builder.spec.ts
@@ -52,9 +52,9 @@ describe('CommandBuilder', () => {
       expect(result).to.equal(builder);
     });
 
-    it('rejects flag values containing line breaks to prevent REPL command injection', () => {
+    it('rejects flag values containing line breaks', () => {
       const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
-      expect(() => builder.addFlags({ team: 'my-team\napps:destroy --confirm victim' })).to.throw(
+      expect(() => builder.addFlags({ team: 'my-team\nsecond-line' })).to.throw(
         /line breaks \(CR\/LF\) are not allowed/
       );
       expect(() => builder.addFlags({ team: 'my-team\rother' })).to.throw(/line breaks/);
@@ -67,7 +67,7 @@ describe('CommandBuilder', () => {
 
     it('names the offending flag and the "flag" kind in the error message', () => {
       const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
-      expect(() => builder.addFlags({ team: 'my-team\napps:destroy' })).to.throw(/Invalid flag value for "team"/);
+      expect(() => builder.addFlags({ team: 'my-team\nsecond-line' })).to.throw(/Invalid flag value for "team"/);
     });
   });
 
@@ -98,14 +98,14 @@ describe('CommandBuilder', () => {
 
     it('rejects positional argument values containing line breaks', () => {
       const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
-      expect(() => builder.addPositionalArguments({ new_name: 'ok\napps:destroy --confirm victim' })).to.throw(
+      expect(() => builder.addPositionalArguments({ new_name: 'ok\nsecond-line' })).to.throw(
         /line breaks \(CR\/LF\) are not allowed/
       );
     });
 
     it('names the offending argument and the "argument" kind in the error message', () => {
       const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
-      expect(() => builder.addPositionalArguments({ new_name: 'ok\napps:destroy' })).to.throw(
+      expect(() => builder.addPositionalArguments({ new_name: 'ok\nsecond-line' })).to.throw(
         /Invalid argument value for "new_name"/
       );
     });
@@ -142,16 +142,16 @@ describe('CommandBuilder', () => {
     });
 
     it('can never emit a command containing carriage returns or line feeds', () => {
-      // The guard rejects CR/LF at add-time, so a value with a line break is never
-      // stored and the build output is always free of them. This test depends on the
-      // guard: it asserts the malicious add throws AND that the command built from the
-      // remaining clean values contains no CR/LF (i.e. the injection left no trace).
+      // Validation rejects CR/LF at add-time, so a value with a line break is never
+      // stored and the build output is always free of them. This test depends on that
+      // validation: it asserts the invalid add throws AND that the command built from
+      // the remaining valid values contains no CR/LF.
       const builder = new CommandBuilder(TOOL_COMMAND_MAP.CREATE_APP);
       builder.addFlags({ region: 'eu' });
-      expect(() => builder.addFlags({ team: 'my-team\napps:destroy --confirm victim' })).to.throw(
+      expect(() => builder.addFlags({ team: 'my-team\nsecond-line' })).to.throw(
         /line breaks \(CR\/LF\) are not allowed/
       );
-      expect(() => builder.addPositionalArguments({ app: 'my-app\rmalicious' })).to.throw(
+      expect(() => builder.addPositionalArguments({ app: 'my-app\rsecond-line' })).to.throw(
         /line breaks \(CR\/LF\) are not allowed/
       );
       const command = builder.build();

--- a/src/utils/command-builder.spec.ts
+++ b/src/utils/command-builder.spec.ts
@@ -51,6 +51,19 @@ describe('CommandBuilder', () => {
       const result = builder.addFlags({ all: true });
       expect(result).to.equal(builder);
     });
+
+    it('rejects flag values containing line breaks to prevent REPL command injection', () => {
+      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      expect(() => builder.addFlags({ team: 'my-team\napps:destroy --confirm victim' })).to.throw(
+        /line breaks \(CR\/LF\) are not allowed/
+      );
+      expect(() => builder.addFlags({ team: 'my-team\rother' })).to.throw(/line breaks/);
+    });
+
+    it('still allows flag values that contain spaces (only line breaks are rejected)', () => {
+      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      expect(() => builder.addFlags({ team: 'my team' })).to.not.throw();
+    });
   });
 
   describe('addPositionalArguments', () => {
@@ -76,6 +89,13 @@ describe('CommandBuilder', () => {
       const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
       const result = builder.addPositionalArguments({ new_name: 'new-app-name' });
       expect(result).to.equal(builder);
+    });
+
+    it('rejects positional argument values containing line breaks', () => {
+      const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
+      expect(() => builder.addPositionalArguments({ new_name: 'ok\napps:destroy --confirm victim' })).to.throw(
+        /line breaks \(CR\/LF\) are not allowed/
+      );
     });
   });
 

--- a/src/utils/command-builder.spec.ts
+++ b/src/utils/command-builder.spec.ts
@@ -64,6 +64,11 @@ describe('CommandBuilder', () => {
       const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
       expect(() => builder.addFlags({ team: 'my team' })).to.not.throw();
     });
+
+    it('names the offending flag and the "flag" kind in the error message', () => {
+      const builder = new CommandBuilder(TOOL_COMMAND_MAP.LIST_APPS);
+      expect(() => builder.addFlags({ team: 'my-team\napps:destroy' })).to.throw(/Invalid flag value for "team"/);
+    });
   });
 
   describe('addPositionalArguments', () => {
@@ -97,6 +102,13 @@ describe('CommandBuilder', () => {
         /line breaks \(CR\/LF\) are not allowed/
       );
     });
+
+    it('names the offending argument and the "argument" kind in the error message', () => {
+      const builder = new CommandBuilder(TOOL_COMMAND_MAP.RENAME_APP);
+      expect(() => builder.addPositionalArguments({ new_name: 'ok\napps:destroy' })).to.throw(
+        /Invalid argument value for "new_name"/
+      );
+    });
   });
 
   describe('build', () => {
@@ -127,6 +139,24 @@ describe('CommandBuilder', () => {
       const builder = new CommandBuilder(TOOL_COMMAND_MAP.CREATE_APP);
       builder.addFlags({ region: 'eu' }).addPositionalArguments({ app: 'my-app' }).addFlags({ team: 'my-team' });
       expect(builder.build()).to.equal('apps:create --region=eu --team=my-team -- my-app');
+    });
+
+    it('can never emit a command containing carriage returns or line feeds', () => {
+      // The guard rejects CR/LF at add-time, so a value with a line break is never
+      // stored and the build output is always free of them. This test depends on the
+      // guard: it asserts the malicious add throws AND that the command built from the
+      // remaining clean values contains no CR/LF (i.e. the injection left no trace).
+      const builder = new CommandBuilder(TOOL_COMMAND_MAP.CREATE_APP);
+      builder.addFlags({ region: 'eu' });
+      expect(() => builder.addFlags({ team: 'my-team\napps:destroy --confirm victim' })).to.throw(
+        /line breaks \(CR\/LF\) are not allowed/
+      );
+      expect(() => builder.addPositionalArguments({ app: 'my-app\rmalicious' })).to.throw(
+        /line breaks \(CR\/LF\) are not allowed/
+      );
+      const command = builder.build();
+      expect(command).to.not.match(/[\r\n]/);
+      expect(command).to.equal('apps:create --region=eu');
     });
   });
 });

--- a/src/utils/command-builder.ts
+++ b/src/utils/command-builder.ts
@@ -1,12 +1,12 @@
 /**
- * Characters that must never appear in a flag value or positional argument.
+ * Characters that are not permitted in a flag value or positional argument.
  *
  * Each built command is delivered to the Heroku CLI as a single line — the REPL
- * writes `command + '\n'` to the CLI process's stdin (see `HerokuREPL`). A carriage
- * return or line feed embedded in a value would therefore terminate the current
- * command and begin another, allowing an untrusted value to inject an additional,
- * unintended CLI command into the stream. There is no legitimate reason for a flag
- * value or positional argument to contain a line break, so they are rejected.
+ * writes `command + '\n'` to the CLI process's stdin (see `HerokuREPL`). Because
+ * commands are line-delimited, a value that spans multiple lines would not be
+ * handled as a single, self-contained value. There is no legitimate reason for a
+ * flag value or positional argument to contain a line break, so we apply strict
+ * input validation and reject them.
  */
 const LINE_BREAK_PATTERN = /[\r\n]/;
 
@@ -29,7 +29,7 @@ export class CommandBuilder {
   }
 
   /**
-   * Rejects values that would break out of the single command line they belong to.
+   * Validates that a value is a single line, as required for a well-formed command.
    *
    * @param kind - Whether the value is a flag value or a positional argument (for the error message).
    * @param name - The flag/argument name the value is associated with (for the error message).
@@ -39,7 +39,7 @@ export class CommandBuilder {
   private static assertNoLineBreaks(kind: 'argument' | 'flag', name: string, value: string): void {
     if (LINE_BREAK_PATTERN.test(value)) {
       throw new Error(
-        `Invalid ${kind} value for "${name}": line breaks (CR/LF) are not allowed. Commands are sent one per line to the Heroku CLI, so an embedded newline would be interpreted as the start of a separate command.`
+        `Invalid ${kind} value for "${name}": line breaks (CR/LF) are not allowed. Commands are sent one per line to the Heroku CLI, so a value must be contained on a single line.`
       );
     }
   }

--- a/src/utils/command-builder.ts
+++ b/src/utils/command-builder.ts
@@ -1,4 +1,16 @@
 /**
+ * Characters that must never appear in a flag value or positional argument.
+ *
+ * Each built command is delivered to the Heroku CLI as a single line — the REPL
+ * writes `command + '\n'` to the CLI process's stdin (see `HerokuREPL`). A carriage
+ * return or line feed embedded in a value would therefore terminate the current
+ * command and begin another, allowing an untrusted value to inject an additional,
+ * unintended CLI command into the stream. There is no legitimate reason for a flag
+ * value or positional argument to contain a line break, so they are rejected.
+ */
+const LINE_BREAK_PATTERN = /[\r\n]/;
+
+/**
  * A builder class for constructing Heroku CLI commands with flags and positional arguments.
  * This class provides a fluent interface for building command-line arguments in a structured way.
  */
@@ -17,6 +29,22 @@ export class CommandBuilder {
   }
 
   /**
+   * Rejects values that would break out of the single command line they belong to.
+   *
+   * @param kind - Whether the value is a flag value or a positional argument (for the error message).
+   * @param name - The flag/argument name the value is associated with (for the error message).
+   * @param value - The value to validate.
+   * @throws {Error} If the value contains a carriage return or line feed.
+   */
+  private static assertNoLineBreaks(kind: 'argument' | 'flag', name: string, value: string): void {
+    if (LINE_BREAK_PATTERN.test(value)) {
+      throw new Error(
+        `Invalid ${kind} value for "${name}": line breaks (CR/LF) are not allowed. Commands are sent one per line to the Heroku CLI, so an embedded newline would be interpreted as the start of a separate command.`
+      );
+    }
+  }
+
+  /**
    * Adds command-line flags to the command.
    *
    * @param flags - An object containing flag names and their values. Boolean flags are added without values,
@@ -27,7 +55,10 @@ export class CommandBuilder {
     for (const [flag, value] of Object.entries(flags)) {
       if (value) {
         if (typeof value === 'boolean') this.flags.push(`--${flag}`);
-        else this.flags.push(`--${flag}=${value}`);
+        else {
+          CommandBuilder.assertNoLineBreaks('flag', flag, value);
+          this.flags.push(`--${flag}=${value}`);
+        }
       }
     }
     return this;
@@ -40,8 +71,11 @@ export class CommandBuilder {
    * @returns The builder instance for method chaining
    */
   public addPositionalArguments(args: Record<string, string | undefined>): this {
-    for (const [, value] of Object.entries(args)) {
-      if (value) this.args.push(value);
+    for (const [name, value] of Object.entries(args)) {
+      if (value) {
+        CommandBuilder.assertNoLineBreaks('argument', name, value);
+        this.args.push(value);
+      }
     }
     return this;
   }


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

@anir0y created a PR to fix a bug and I am cherry picking those changes and adding some tests to get this merged into the MCP server.  We need to do this for CI tests to properly pass.

Reject CR/LF in CLI flag values and positional arguments

Commands are sent one-per-line to the Heroku CLI's stdin, so a newline embedded in an untrusted value could terminate the current command and inject a second one. CommandBuilder now rejects any flag value or positional argument containing \r or \n.

- command-builder.ts: add assertNoLineBreaks guard on flag values and positional args
- Tests cover the builder, REPL, and the apps/data tools

## Type of Change

### Breaking Changes (major semver update)

- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)

- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)

- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing

Passing CI will suffice.

## Screenshots (if applicable)

## Related Issues

GitHub issue: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002e4SyrYAE/view
