### PR TITLE
fix: stop deploy packer from following out-of-root symlinks

### DIFF
--- a/src/utils/tarball.spec.ts
+++ b/src/utils/tarball.spec.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
+import zlib from 'node:zlib';
 import { execSync } from 'node:child_process';
 import { expect } from 'chai';
 import { packSources, getSourceFilePaths, GeneratedContent } from './tarball.js';
@@ -113,6 +114,72 @@ describe('tarball utils', () => {
       expect(result).to.include(path.join(tempDir, 'dir1/file1.txt'));
       expect(result).to.include(path.join(tempDir, 'dir1/subdir/file2.txt'));
       expect(result).to.include(path.join(tempDir, 'file3.txt'));
+    });
+  });
+
+  // Regression tests for W-23510157 (CWE-59): a tracked/untracked symlink whose
+  // target lives outside the workspace root must never have its target bytes
+  // read into the uploaded source archive.
+  describe('symlink handling (W-23510157)', () => {
+    const SECRET = 'SUPER-SECRET-EXTERNAL-CANARY';
+    let outsideDir: string;
+    let secretPath: string;
+
+    beforeEach(async () => {
+      // A file that lives entirely outside the workspace root.
+      outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'outside-workspace-'));
+      secretPath = path.join(outsideDir, 'secret.txt');
+      await fs.writeFile(secretPath, SECRET);
+    });
+
+    afterEach(async () => {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    });
+
+    it('excludes symlinks whose target is outside the workspace root (walk path)', async () => {
+      await createTempFile('legit.txt', 'legit content');
+      await fs.symlink(secretPath, path.join(tempDir, 'evil-link.txt'));
+
+      const result = await getSourceFilePaths(tempDir);
+
+      expect(result).to.include(path.join(tempDir, 'legit.txt'));
+      expect(result).to.not.include(path.join(tempDir, 'evil-link.txt'));
+    });
+
+    it('does not pack the contents of an out-of-root symlink target', async () => {
+      await createTempFile('legit.txt', 'legit content');
+      await fs.symlink(secretPath, path.join(tempDir, 'evil-link.txt'));
+
+      const tarball = await packSources(tempDir);
+      const unzipped = zlib.gunzipSync(tarball).toString('binary');
+
+      expect(unzipped).to.include('legit content');
+      expect(unzipped).to.not.include(SECRET);
+    });
+
+    it('excludes tracked symlinks that escape root via the git ls-files path', async () => {
+      execSync('git init -q', { cwd: tempDir });
+      await createTempFile('legit.txt', 'legit content');
+      // `git ls-files -o` lists untracked, non-ignored files, so no commit is required
+      // for the symlink path to reach getSourceFilePaths().
+      await fs.symlink(secretPath, path.join(tempDir, 'evil-link.txt'));
+
+      const result = await getSourceFilePaths(tempDir);
+      const tarball = await packSources(tempDir);
+      const unzipped = zlib.gunzipSync(tarball).toString('binary');
+
+      expect(result).to.not.include(path.join(tempDir, 'evil-link.txt'));
+      expect(unzipped).to.include('legit content');
+      expect(unzipped).to.not.include(SECRET);
+    });
+
+    it('still includes symlinks that resolve within the workspace root', async () => {
+      await createTempFile('real/target.txt', 'in-tree content');
+      await fs.symlink(path.join(tempDir, 'real/target.txt'), path.join(tempDir, 'inside-link.txt'));
+
+      const result = await getSourceFilePaths(tempDir);
+
+      expect(result).to.include(path.join(tempDir, 'inside-link.txt'));
     });
   });
 });

--- a/src/utils/tarball.ts
+++ b/src/utils/tarball.ts
@@ -1,5 +1,5 @@
 import zlib from 'node:zlib';
-import { readFile, stat, readdir } from 'node:fs/promises';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import * as tar from 'tar-stream';
@@ -42,7 +42,7 @@ export async function packSources(
 
   for (const file of files) {
     try {
-      const content = await readFile(file);
+      const content = await fs.readFile(file);
       const relativePath = path.relative(root!, file);
       pack.entry({ name: relativePath }, Buffer.from(content));
     } catch {
@@ -78,15 +78,24 @@ export async function getSourceFilePaths(root: string): Promise<string[]> {
 
   const paths = result.split('\n').filter((file) => Boolean(file));
 
+  const realRoot = await fs.realpath(root);
   const allFiles: string[] = [];
 
   for (const p of paths) {
     const fullPath = path.join(root, p);
     try {
-      const stats = await stat(fullPath);
-      if (stats.isDirectory()) {
+      const stats = await fs.lstat(fullPath);
+      // Never follow a symlink whose target escapes the workspace root: doing so
+      // would read files outside the deploy source and place them in the uploaded
+      // tarball (W-23510157, CWE-59).
+      if (stats.isSymbolicLink() && (await escapesRoot(realRoot, fullPath))) {
+        continue;
+      }
+      // Resolve the (possibly in-root symlinked) entry to decide file vs. directory.
+      const resolved = await fs.stat(fullPath);
+      if (resolved.isDirectory()) {
         // Recursively get all files in directory
-        const files = await walkDirectory(fullPath);
+        const files = await walkDirectory(fullPath, realRoot);
         allFiles.push(...files);
       } else {
         allFiles.push(fullPath);
@@ -100,22 +109,50 @@ export async function getSourceFilePaths(root: string): Promise<string[]> {
 }
 
 /**
+ * Determines whether a path's real (symlink-resolved) location escapes the
+ * workspace root. Following a repository symlink whose target lives outside the
+ * selected root would let a malicious repository smuggle unrelated files from the
+ * developer's machine into the uploaded source archive (W-23510157, CWE-59).
+ *
+ * @param realRoot The canonical (realpath-resolved) workspace root
+ * @param candidate The path whose resolved target should be checked
+ * @returns true when the resolved target is outside realRoot or cannot be resolved
+ */
+async function escapesRoot(realRoot: string, candidate: string): Promise<boolean> {
+  try {
+    const realCandidate = await fs.realpath(candidate);
+    const relative = path.relative(realRoot, realCandidate);
+    return relative.startsWith('..') || path.isAbsolute(relative);
+  } catch {
+    // A dangling or otherwise unresolvable link is excluded rather than read.
+    return true;
+  }
+}
+
+/**
  * Walks a directory and returns all file paths
  *
  * @param dir The directory to walk
+ * @param realRoot The canonical (realpath-resolved) workspace root used to reject
+ *   symlinks that resolve outside of it (W-23510157, CWE-59)
  * @returns A promise that resolves to an array of file paths
  */
-async function walkDirectory(dir: string): Promise<string[]> {
+async function walkDirectory(dir: string, realRoot: string): Promise<string[]> {
   const files: string[] = [];
 
   try {
-    const entries = await readdir(dir, { withFileTypes: true });
+    const entries = await fs.readdir(dir, { withFileTypes: true });
 
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
 
+      // Never follow a symlink whose target escapes the workspace root.
+      if (entry.isSymbolicLink() && (await escapesRoot(realRoot, fullPath))) {
+        continue;
+      }
+
       if (entry.isDirectory()) {
-        const subFiles = await walkDirectory(fullPath);
+        const subFiles = await walkDirectory(fullPath, realRoot);
         files.push(...subFiles);
       } else {
         files.push(fullPath);


### PR DESCRIPTION
## Summary

`deploy_to_heroku` could read files from outside the folder you asked it to deploy and upload them to Heroku inside your source tarball.

When packaging a workspace, the tool lists files with `git ls-files` and then calls `stat()` and `readFile()` on each one. Both of those follow symlinks. So if a repository contains a symlink that points somewhere outside the selected root (for example, a link named `config.txt` that actually points to `/proc/self/environ`), the packer would quietly read that external file and pack its contents into the tarball sent to Heroku. Build code in the repo could then read those bytes.

This means a repository you cloned from someone else could pull files off your machine the moment you deploy it — without any prompt-injection or special access. It was reported through the bug bounty program (W-23510157, CWE-59).

### The fix

`getSourceFilePaths()` and `walkDirectory()` now:

1. Use `lstat()` to notice when a path is a symlink.
2. Resolve the symlink's real target with `realpath()` and check whether it stays inside the workspace root.
3. Skip any symlink whose target escapes the root — its contents are never read or packed.

Symlinks that point to files *inside* the root are still followed, so normal deploys are unaffected.

## Type of Change

### Breaking Changes (major semver update)

- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)

- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)

- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

**Notes**:

Added regression tests in `src/utils/tarball.spec.ts`. They fail against the old code (the out-of-root file lands in the tarball) and pass with this fix. They cover both code paths that walk the workspace: the `git ls-files` path and the plain directory-walk fallback. A test also confirms that a legitimate symlink pointing inside the root is still included.

**Steps**:

1. `npm test` — full suite passes (207 tests).
2. Or: `npx mocha src/utils/tarball.spec.ts --grep "symlink handling"` to run just the new tests.

## Screenshots (if applicable)

N/A

## Related Issues

GUS work item: [W-23510157](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002fFB5xYAG/view)
